### PR TITLE
JSON serialization

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -29,6 +29,7 @@ dependencies:
 - bifunctors
 - containers
 - extra
+- json
 library:
   source-dirs: src
 

--- a/src/Language/Syntax.hs
+++ b/src/Language/Syntax.hs
@@ -3,13 +3,13 @@
 
 module Language.Syntax where
 import Data.List
-import Data.Typeable
 import Text.JSON.Generic
 import qualified Data.Set as S
 type Name = String
 
 -- | Game datatype
-data Game = Game Name BoardDef InputDef [ValDef] deriving(Data, Typeable)
+data Game = Game Name BoardDef InputDef [ValDef]
+  deriving (Data)
 
 instance Show Game where
   show (Game n b i vs) = "Game : " ++ n ++ "\n"
@@ -18,13 +18,15 @@ instance Show Game where
                          ++ intercalate ("\n\n\n") (map show vs)
 
 -- | Board definition: mxn board of type Type
-data BoardDef = BoardDef Integer Integer Type deriving(Data, Typeable)
+data BoardDef = BoardDef Integer Integer Type
+  deriving (Data)
 
 instance Show BoardDef where
   show (BoardDef i1 i2 t) = "Board : Grid(" ++ show i1 ++ "," ++ show i2 ++ ") of " ++ show t
 
 -- | Input definition: Player inputs must be an accepted type
-data InputDef = InputDef Type deriving(Data, Typeable)
+data InputDef = InputDef Type
+  deriving (Data)
 
 instance Show InputDef where
   show (InputDef t) = "Input : " ++ show t
@@ -32,7 +34,7 @@ instance Show InputDef where
 -- | Top level values are signatures paired with either an ordinary 'Equation'
 data ValDef = Val Signature Equation
   | BVal Signature BoardEq -- ^ Or a 'BoardEq'
-   deriving (Eq, Data, Typeable)
+   deriving (Eq, Data)
 
 instance Show ValDef where
   show (Val s e) = show s ++ "\n" ++ show e
@@ -40,14 +42,14 @@ instance Show ValDef where
 
 -- | Signatures are a product of name and type.
 data Signature = Sig Name Type
-   deriving (Eq)
+   deriving (Eq, Data)
 
 instance Show Signature where
   show (Sig n t) = n ++ " : " ++ show t
 
 -- | Parameter lists are lists of 'Name'
 data Parlist = Pars [Name]
-   deriving (Eq)
+   deriving (Eq, Data)
 
 instance Show Parlist where
   show (Pars xs) = "(" ++ intercalate (" , ") (xs) ++ ")"
@@ -55,7 +57,7 @@ instance Show Parlist where
 -- | Equations can either be
 data Equation = Veq Name Expr -- ^ Value equations (a mapping from 'Name' to 'Expr')
               | Feq Name Parlist Expr -- ^ Function equations (a 'Name', list of params 'Parlist', and the 'Expr' that may possibly use those parameters.
-   deriving (Eq)
+   deriving (Eq, Data)
 
 instance Show Equation where
   show (Veq n e) = n ++ " = " ++ show e
@@ -64,7 +66,8 @@ instance Show Equation where
 -- | Board equations can either be
 data BoardEq = PosDef Name Expr Expr Expr -- ^ Position defition: an assignment to a specific position
              | RegDef Name Expr Expr -- ^ A region definition, an assignment to multiple positions
-   deriving (Eq)
+   deriving (Eq, Data)
+
 instance Show BoardEq where
   show (PosDef n i1 i2 e) = n ++ "(" ++ show i1 ++ ", " ++ show i2 ++ ")" ++ "=" ++ show e
   show (RegDef n e1 e2) = n ++ "(" ++ show e1 ++ ")" ++ "=" ++ show e2
@@ -80,7 +83,7 @@ data Btype = Booltype -- ^ Boolean
            | Position -- ^ A position, specified by the board description
            | Positions -- ^ The list of all positions
            | Undef -- ^ Only occurs when typechecking. The user cannot define anything of this type. (I could use 'undefined' everywhere I use this, but one false move and the whole program crashes)
-   deriving (Eq)
+   deriving (Eq, Data)
 
 instance Show Btype where
   show Booltype = "Bool"
@@ -95,6 +98,7 @@ instance Show Btype where
 
 -- | Xtypes are sum types, but restricted by the semantics to only contain Symbols after the atomic type.
 data Xtype = X Btype (S.Set Name)
+  deriving (Data)
 
 instance Eq Xtype where
   -- (X (Symbol s) bs) == (X t1 xs) | not . S.null $ xs= s `S.member` xs
@@ -109,14 +113,14 @@ instance Show Xtype where
 
 -- | Tuples can only contain Xtypes (no sub-tuples)
 data Tuptype = Tup [Xtype]
-   deriving (Eq)
+   deriving (Eq, Data)
 
 instance Show Tuptype where
   show (Tup xs) = "(" ++ intercalate (",") (map show xs) ++ ")"
 
 -- | A plain type is either a tuple, or an extended type
 data Ptype = Pext Xtype | Pt Tuptype
-   deriving (Eq)
+   deriving (Eq, Data)
 
 instance Show Ptype where
   show (Pext x) = show x
@@ -124,14 +128,14 @@ instance Show Ptype where
 
 -- | A function type can be from a plain type to a plain type (no curried functions)
 data Ftype = Ft Ptype Ptype
-   deriving (Eq)
+   deriving (Eq, Data)
 
 instance Show Ftype where
   show (Ft t1 t2) = show t1 ++ " -> " ++ show t2
 
 -- | A type is either a plain type or a function.
 data Type = Plain Ptype | Function Ftype
-   deriving (Eq)
+   deriving (Eq, Data)
 
 instance Show Type where
   show (Plain t) = show t
@@ -149,7 +153,7 @@ data Expr = I Integer -- ^ Integer expression
           | If Expr Expr Expr -- ^ Conditional expression
           | While Name Name Expr -- ^ While loop (could be While Expr Expr Expr if we make the App change suggested above)
           | Case Name [(Name, Expr)] Expr -- ^ case expression: the final pair is if we have the atomic type, and then we downcast the Xtype back to its regular form.
-   deriving (Eq)
+   deriving (Eq, Data)
 instance Show Expr where
   show (I i) = show i
   show (S s) = s
@@ -174,7 +178,7 @@ data Op = Plus
         | Less
         | Xor
         | Greater
-   deriving (Eq)
+   deriving (Eq, Data)
 instance Show Op where
   show Plus = " + "
   show Minus = " - "

--- a/src/Language/Syntax.hs
+++ b/src/Language/Syntax.hs
@@ -1,12 +1,15 @@
+{-# LANGUAGE DeriveDataTypeable #-}
 -- | Abstract syntax for BOGL
 
 module Language.Syntax where
 import Data.List
+import Data.Typeable
+import Text.JSON.Generic
 import qualified Data.Set as S
 type Name = String
 
 -- | Game datatype
-data Game = Game Name BoardDef InputDef [ValDef]
+data Game = Game Name BoardDef InputDef [ValDef] deriving(Data, Typeable)
 
 instance Show Game where
   show (Game n b i vs) = "Game : " ++ n ++ "\n"
@@ -15,13 +18,13 @@ instance Show Game where
                          ++ intercalate ("\n\n\n") (map show vs)
 
 -- | Board definition: mxn board of type Type
-data BoardDef = BoardDef Integer Integer Type
+data BoardDef = BoardDef Integer Integer Type deriving(Data, Typeable)
 
 instance Show BoardDef where
   show (BoardDef i1 i2 t) = "Board : Grid(" ++ show i1 ++ "," ++ show i2 ++ ") of " ++ show t
 
 -- | Input definition: Player inputs must be an accepted type
-data InputDef = InputDef Type
+data InputDef = InputDef Type deriving(Data, Typeable)
 
 instance Show InputDef where
   show (InputDef t) = "Input : " ++ show t
@@ -29,7 +32,7 @@ instance Show InputDef where
 -- | Top level values are signatures paired with either an ordinary 'Equation'
 data ValDef = Val Signature Equation
   | BVal Signature BoardEq -- ^ Or a 'BoardEq'
-   deriving (Eq)
+   deriving (Eq, Data, Typeable)
 
 instance Show ValDef where
   show (Val s e) = show s ++ "\n" ++ show e
@@ -37,14 +40,14 @@ instance Show ValDef where
 
 -- | Signatures are a product of name and type.
 data Signature = Sig Name Type
-   deriving (Eq) 
+   deriving (Eq)
 
 instance Show Signature where
   show (Sig n t) = n ++ " : " ++ show t
 
 -- | Parameter lists are lists of 'Name'
 data Parlist = Pars [Name]
-   deriving (Eq) 
+   deriving (Eq)
 
 instance Show Parlist where
   show (Pars xs) = "(" ++ intercalate (" , ") (xs) ++ ")"
@@ -52,7 +55,7 @@ instance Show Parlist where
 -- | Equations can either be
 data Equation = Veq Name Expr -- ^ Value equations (a mapping from 'Name' to 'Expr')
               | Feq Name Parlist Expr -- ^ Function equations (a 'Name', list of params 'Parlist', and the 'Expr' that may possibly use those parameters.
-   deriving (Eq)              
+   deriving (Eq)
 
 instance Show Equation where
   show (Veq n e) = n ++ " = " ++ show e
@@ -77,7 +80,7 @@ data Btype = Booltype -- ^ Boolean
            | Position -- ^ A position, specified by the board description
            | Positions -- ^ The list of all positions
            | Undef -- ^ Only occurs when typechecking. The user cannot define anything of this type. (I could use 'undefined' everywhere I use this, but one false move and the whole program crashes)
-   deriving (Eq) 
+   deriving (Eq)
 
 instance Show Btype where
   show Booltype = "Bool"
@@ -106,14 +109,14 @@ instance Show Xtype where
 
 -- | Tuples can only contain Xtypes (no sub-tuples)
 data Tuptype = Tup [Xtype]
-   deriving (Eq) 
+   deriving (Eq)
 
 instance Show Tuptype where
   show (Tup xs) = "(" ++ intercalate (",") (map show xs) ++ ")"
 
 -- | A plain type is either a tuple, or an extended type
 data Ptype = Pext Xtype | Pt Tuptype
-   deriving (Eq) 
+   deriving (Eq)
 
 instance Show Ptype where
   show (Pext x) = show x
@@ -121,14 +124,14 @@ instance Show Ptype where
 
 -- | A function type can be from a plain type to a plain type (no curried functions)
 data Ftype = Ft Ptype Ptype
-   deriving (Eq) 
+   deriving (Eq)
 
 instance Show Ftype where
   show (Ft t1 t2) = show t1 ++ " -> " ++ show t2
 
 -- | A type is either a plain type or a function.
 data Type = Plain Ptype | Function Ftype
-   deriving (Eq) 
+   deriving (Eq)
 
 instance Show Type where
   show (Plain t) = show t
@@ -171,7 +174,7 @@ data Op = Plus
         | Less
         | Xor
         | Greater
-   deriving (Eq) 
+   deriving (Eq)
 instance Show Op where
   show Plus = " + "
   show Minus = " - "

--- a/src/Runtime/Serializer.hs
+++ b/src/Runtime/Serializer.hs
@@ -12,49 +12,37 @@
 module Runtime.Serializer where
 
 import Parser.Parser
-
 import Text.JSON.Generic
-import Data.Typeable
 import Language.Syntax
 
-data Address = Address
-    { house  :: Integer
-    , street :: String
-    , city   :: String
-    , state  :: String
-    , zip    :: Integer
-    } deriving (Show, Data, Typeable)
 
-data Person = Person
-    { name    :: String
-    , age     :: Integer
-    , address :: Address
-    } deriving (Show, Data, Typeable)
-
-aa :: String
-aa = "{\"name\": \"some body\", \"age\" : 23, \"address\" : {\"house\" : 285, \"street\" : \"7th Ave.\", \"city\" : \"New York\", \"state\" : \"New York\", \"zip\" : 10001}}"
-
---main = print (decodeJSON aa :: Person)
-
---data GameJSON = GameJSON
-  --{
-  --  name  :: Name
-    --board :: BoardDefJSON
-    --input :: InputDefJSON
-    --vals  :: ValDefJSON
-  --}
-
---encode :: Board -> String
-
---decodeGame :: String -> Name
---decodeGame jsonStr = decodeJSON jsonStr :: Board
+-- encodes the game as a JSON object
+encodeGame :: Game -> String
+encodeGame g = encodeJSON g
 
 
-ex :: IO ()
-ex = do
+-- decodes a JSON object into a game
+decodeGame :: String -> Game
+decodeGame s = decodeJSON s :: Game
+
+
+-- test Game encode functionality
+encode_test :: IO ()
+encode_test = do
   parsed <- parseGameFile "src/Runtime/example1.bgl"
   case parsed of
     Just g  -> do
-      print (encodeJSON g)
+      print (encodeGame g)
+      return ()
+    Nothing -> return () -- do nothing...
+
+
+-- test Game decode functionality
+decode_test :: IO ()
+decode_test = do
+  parsed <- parseGameFile "src/Runtime/example1.bgl"
+  case parsed of
+    Just g  -> do
+      print (decodeGame (encodeGame g))
       return ()
     Nothing -> return () -- do nothing...

--- a/src/Runtime/Serializer.hs
+++ b/src/Runtime/Serializer.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+-- Serializer.hs
+--
+-- Handles un/serializing boards and related data,
+-- primarily for stateless communication with the Spiel frontend
+---- Serializer.hs
+--
+-- Handles un/serializing boards and related data,
+-- primarily for stateless communication with the Spiel frontend
+--
+
+module Runtime.Serializer where
+
+import Parser.Parser
+
+import Text.JSON.Generic
+import Data.Typeable
+import Language.Syntax
+
+data Address = Address
+    { house  :: Integer
+    , street :: String
+    , city   :: String
+    , state  :: String
+    , zip    :: Integer
+    } deriving (Show, Data, Typeable)
+
+data Person = Person
+    { name    :: String
+    , age     :: Integer
+    , address :: Address
+    } deriving (Show, Data, Typeable)
+
+aa :: String
+aa = "{\"name\": \"some body\", \"age\" : 23, \"address\" : {\"house\" : 285, \"street\" : \"7th Ave.\", \"city\" : \"New York\", \"state\" : \"New York\", \"zip\" : 10001}}"
+
+--main = print (decodeJSON aa :: Person)
+
+--data GameJSON = GameJSON
+  --{
+  --  name  :: Name
+    --board :: BoardDefJSON
+    --input :: InputDefJSON
+    --vals  :: ValDefJSON
+  --}
+
+--encode :: Board -> String
+
+--decodeGame :: String -> Name
+--decodeGame jsonStr = decodeJSON jsonStr :: Board
+
+
+ex :: IO ()
+ex = do
+  parsed <- parseGameFile "src/Runtime/example1.bgl"
+  case parsed of
+    Just g  -> do
+      print (encodeJSON g)
+      return ()
+    Nothing -> return () -- do nothing...

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -1,4 +1,4 @@
 import Test.DocTest
 
 main :: IO ()
-main = doctest ["-isrc", "src/Language/Syntax.hs", "src/Runtime/Eval.hs", "src/Parser/Parser.hs"] 
+main = doctest ["-isrc", "src/Language/Syntax.hs", "src/Runtime/Eval.hs", "src/Parser/Parser.hs"]


### PR DESCRIPTION
Closes #7 , functionality for JSON serialization. This comes in with the following functions under the new Serializer.hs file, ```encodeGame``` and ```decodeGame```. 

Both are fairly standard, and after looking through quite a lot of documentation I went for using **DeriveDataTypeable** with the **Text.JSON.Generic** import, which allows for automatic encoding/decoding of user-defined types.

The only issue is that the usage of **DeriveDataTypeable** requires an additional language extension to be enabled, marked at the top of both the **Syntax** and **Serializer** files. I don't think this will be a problem, but it will be required for this to work on other platforms as well (mine was tested on mac, assuming it will work on windows as well).