### PR TITLE
Adds /file to API

### DIFF
--- a/src/API/JSONData.hs
+++ b/src/API/JSONData.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+--
+-- JSONData.hs
+--
+-- Defines JSON data for the API
+--
+
+module API.JSONData where
+
+
+import Data.Aeson
+import Data.Aeson.TH
+
+
+-- representation of a file that will be saved by the user
+data SpielFile = SpielFile {
+  fileName  :: String,
+  content   :: String
+} deriving (Eq, Show)
+
+
+-- representation of input to the repl, from the user
+data SpielCommand = SpielCommand {
+    file   :: String,
+    inputs :: [String]
+  } deriving (Eq, Show)
+
+
+-- representation of the response from the Repl
+data SpielResponse = SpielResponse {
+    -- TODO implment as [Either Exception Val] instead of [String]
+    responses :: [String]
+  } deriving (Eq, Show)
+
+
+-- derive JSON for cmd & response
+$(deriveJSON defaultOptions ''SpielFile)
+$(deriveJSON defaultOptions ''SpielCommand)
+$(deriveJSON defaultOptions ''SpielResponse)

--- a/src/API/JSONData.hs
+++ b/src/API/JSONData.hs
@@ -27,10 +27,19 @@ data SpielCommand = SpielCommand {
   } deriving (Eq, Show)
 
 
--- representation of the response from the Repl
-data SpielResponse = SpielResponse {
-    -- TODO implment as [Either Exception Val] instead of [String]
-    responses :: [String]
+-- representation of a collection of responses from Spiel
+data SpielResponse =
+  SpielOK String |
+  SpielError String
+  deriving(Eq)
+
+instance Show SpielResponse where
+  show (SpielOK s)     = show s
+  show (SpielError s)  = "ERROR: " ++ show s
+
+data SpielResponses = SpielResponses {
+    -- TODO implement as [Either Exception Val] instead of [String]
+    responses :: [SpielResponse]
   } deriving (Eq, Show)
 
 
@@ -38,3 +47,4 @@ data SpielResponse = SpielResponse {
 $(deriveJSON defaultOptions ''SpielFile)
 $(deriveJSON defaultOptions ''SpielCommand)
 $(deriveJSON defaultOptions ''SpielResponse)
+$(deriveJSON defaultOptions ''SpielResponses)

--- a/src/API/RunFileWithCommands.hs
+++ b/src/API/RunFileWithCommands.hs
@@ -18,23 +18,23 @@ import Control.Monad.IO.Class
 
 
 -- runs a file with given commands, lifting it into Handler
-handleRunFileWithCommands :: SpielCommand -> Handler SpielResponse
+handleRunFileWithCommands :: SpielCommand -> Handler SpielResponses
 handleRunFileWithCommands sc = do
   (liftIO (_runFileWithCommands sc))
 
 
 -- runs command as IO
-_runFileWithCommands :: SpielCommand -> IO SpielResponse
+_runFileWithCommands :: SpielCommand -> IO SpielResponses
 _runFileWithCommands (SpielCommand gameFile inpt) = do
   Just game <- parseGameFile gameFile
   let check = success (tc game)
   -- (Typechecker.Monad.Env, [Either (ValDef, Typechecker.Monad.TypeError) (Name, Type)])
   -- (Holes, [Either (Value , and associated error (Name, Type))])
-  if check then return (SpielResponse (serverRepl game inpt)) else return (SpielResponse ["ERR: Could not parse game file!"])
+  if check then return (SpielResponses (serverRepl game inpt)) else return (SpielResponses [SpielError "Could not parse game file!"])
 
 
 -- handles running a command in the repl from the server
-serverRepl :: Game -> [String] -> [String]
+serverRepl :: Game -> [String] -> [SpielResponse]
 serverRepl _ [] = []
 serverRepl g@(Game _ i@(BoardDef (szx,szy) _) b vs) (inpt:ils) = do
   case parseLine inpt of
@@ -44,16 +44,16 @@ serverRepl g@(Game _ i@(BoardDef (szx,szy) _) b vs) (inpt:ils) = do
           case runWithBuffer (bindings_ (szx, szy) vs) [] x of
 
             -- TODO program terminated, potentially more data desired
-            Right (terminated) -> ((show terminated):(serverRepl g ils))
+            Right (terminated) -> ((SpielOK ("program ended: " ++ (show terminated))):(serverRepl g ils))
 
             -- TODO, board and tape returned, program needs more input
-            Left ((Vboard b'), _) -> ((show b'):(serverRepl g ils)) -- used to be ((Vboard b'), t')
+            Left ((Vboard b'), _) -> ((SpielOK (show b')):(serverRepl g ils)) -- used to be ((Vboard b'), t')
 
             -- TODO runtime error encountered
-            Left err -> ((show err):(serverRepl g ils))
+            Left err -> ((SpielError ("runtime error: " ++ (show err))):(serverRepl g ils))
 
         -- TODO typechecker encountered an error in the environment (unlikely not to happen)
-        Left err -> ((show err):(serverRepl g ils))
+        Left err -> ((SpielError ("typechecker error: " ++ (show err))):(serverRepl g ils))
 
     -- bad parse
-    Left err -> ((show err):(serverRepl g ils))
+    Left err -> ((SpielError ("parser error: " ++ (show err))):(serverRepl g ils))

--- a/src/API/RunFileWithCommands.hs
+++ b/src/API/RunFileWithCommands.hs
@@ -1,0 +1,59 @@
+--
+-- RunFileWithCommands.hs
+--
+-- Endpoint for running a given file with a list of commands
+-- and returning a list of responses
+--
+
+module API.RunFileWithCommands (handleRunFileWithCommands) where
+
+import API.JSONData
+import Servant
+import Parser.Parser
+import Language.Syntax
+import Runtime.Values
+import Typechecker.Typechecker
+import Runtime.Eval
+import Control.Monad.IO.Class
+
+
+-- runs a file with given commands, lifting it into Handler
+handleRunFileWithCommands :: SpielCommand -> Handler SpielResponse
+handleRunFileWithCommands sc = do
+  (liftIO (_runFileWithCommands sc))
+
+
+-- runs command as IO
+_runFileWithCommands :: SpielCommand -> IO SpielResponse
+_runFileWithCommands (SpielCommand gameFile inpt) = do
+  Just game <- parseGameFile gameFile
+  let check = success (tc game)
+  -- (Typechecker.Monad.Env, [Either (ValDef, Typechecker.Monad.TypeError) (Name, Type)])
+  -- (Holes, [Either (Value , and associated error (Name, Type))])
+  if check then return (SpielResponse (serverRepl game inpt)) else return (SpielResponse ["ERR: Could not parse game file!"])
+
+
+-- handles running a command in the repl from the server
+serverRepl :: Game -> [String] -> [String]
+serverRepl _ [] = []
+serverRepl g@(Game _ i@(BoardDef (szx,szy) _) b vs) (inpt:ils) = do
+  case parseLine inpt of
+    Right x -> do
+      case tcexpr (environment i b vs) x of
+        Right _ -> do -- Right t
+          case runWithBuffer (bindings_ (szx, szy) vs) [] x of
+
+            -- TODO program terminated, potentially more data desired
+            Right (terminated) -> ((show terminated):(serverRepl g ils))
+
+            -- TODO, board and tape returned, program needs more input
+            Left ((Vboard b'), _) -> ((show b'):(serverRepl g ils)) -- used to be ((Vboard b'), t')
+
+            -- TODO runtime error encountered
+            Left err -> ((show err):(serverRepl g ils))
+
+        -- TODO typechecker encountered an error in the environment (unlikely not to happen)
+        Left err -> ((show err):(serverRepl g ils))
+
+    -- bad parse
+    Left err -> ((show err):(serverRepl g ils))

--- a/src/API/SaveFile.hs
+++ b/src/API/SaveFile.hs
@@ -19,5 +19,5 @@ handleSaveFile :: SpielFile -> Handler SpielResponse
 handleSaveFile (SpielFile fn contents) = liftIO (do
     -- TODO needs to check if this file was successfully written
     writeFile (fn ++ ".bgl") contents
-    return (SpielResponse [fn ++ " written successfully"])
+    return (SpielResponse [fn ++ ".bgl" ++ " written successfully"])
   )

--- a/src/API/SaveFile.hs
+++ b/src/API/SaveFile.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE DataKinds       #-}
+
+--
+-- SaveFile.hs
+--
+-- Endpoint to handle saving of a file
+--
+
+module API.SaveFile (handleSaveFile) where
+
+import API.JSONData
+import Servant
+import Control.Monad.IO.Class
+import Control.Exception(try,Exception)
+
+-- TODO Change SpielResponse to SpielOK/SpielError
+
+handleSaveFile :: SpielFile -> Handler SpielResponse
+handleSaveFile (SpielFile fn contents) = liftIO (do
+    -- TODO needs to check if this file was successfully written
+    writeFile fn contents
+    return (SpielResponse [fn ++ " written successfully"])
+  )

--- a/src/API/SaveFile.hs
+++ b/src/API/SaveFile.hs
@@ -11,7 +11,6 @@ module API.SaveFile (handleSaveFile) where
 import API.JSONData
 import Servant
 import Control.Monad.IO.Class
-import Control.Exception(try,Exception)
 
 -- TODO Change SpielResponse to SpielOK/SpielError
 
@@ -19,5 +18,5 @@ handleSaveFile :: SpielFile -> Handler SpielResponse
 handleSaveFile (SpielFile fn contents) = liftIO (do
     -- TODO needs to check if this file was successfully written
     writeFile (fn ++ ".bgl") contents
-    return (SpielResponse [fn ++ ".bgl" ++ " written successfully"])
+    return (SpielOK (fn ++ ".bgl" ++ " written successfully"))
   )

--- a/src/API/SaveFile.hs
+++ b/src/API/SaveFile.hs
@@ -18,6 +18,6 @@ import Control.Exception(try,Exception)
 handleSaveFile :: SpielFile -> Handler SpielResponse
 handleSaveFile (SpielFile fn contents) = liftIO (do
     -- TODO needs to check if this file was successfully written
-    writeFile fn contents
+    writeFile (fn ++ ".bgl") contents
     return (SpielResponse [fn ++ " written successfully"])
   )

--- a/src/API/SaveFile.hs
+++ b/src/API/SaveFile.hs
@@ -14,9 +14,9 @@ import Control.Monad.IO.Class
 
 -- TODO Change SpielResponse to SpielOK/SpielError
 
-handleSaveFile :: SpielFile -> Handler SpielResponse
+handleSaveFile :: SpielFile -> Handler SpielResponses
 handleSaveFile (SpielFile fn contents) = liftIO (do
     -- TODO needs to check if this file was successfully written
     writeFile (fn ++ ".bgl") contents
-    return (SpielOK (fn ++ ".bgl" ++ " written successfully"))
+    return (SpielResponses [(SpielOK (fn ++ ".bgl" ++ " written successfully"))])
   )

--- a/src/API/Server.hs
+++ b/src/API/Server.hs
@@ -23,7 +23,7 @@ import Servant
 
 
 
-type SpielApi = "runFileWithCommands" :> ReqBody '[JSON] SpielCommand :> Post '[JSON] SpielResponse
+type SpielApi = "runFileWithCommands" :> ReqBody '[JSON] SpielCommand :> Post '[JSON] SpielResponses
   :<|> "file" :> ReqBody '[JSON] SpielFile :> Post '[JSON] SpielResponse
   :<|> "test" :> Get '[JSON] SpielResponse
 

--- a/src/API/Server.hs
+++ b/src/API/Server.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE DataKinds       #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DataKinds       #-}
 {-# LANGUAGE TypeOperators   #-}
 -- {-# LANGUAGE OverloadedStrings #-}
 
@@ -12,43 +12,39 @@
 --
 module API.Server (startServer, serverApp) where
 
-import Control.Concurrent
-import Control.Monad
-import Data.Aeson
-import Data.Aeson.TH
+import API.JSONData
+import API.RunFileWithCommands
+import API.Test
+import API.SaveFile
+
 import Network.Wai
 import Network.Wai.Handler.Warp
 import Servant
-import Parser.Parser
-import Language.Syntax
-import Runtime.Values
-import Typechecker.Typechecker
-import Runtime.Eval
-import Control.Monad.IO.Class
 
--- representation of input to the repl, from the user
-data SpielCommand = SpielCommand {
-    file   :: String,
-    inputs :: [String]
-  } deriving (Eq, Show)
 
--- representation of the response from the Repl
-data SpielResponse = SpielResponse {
-    -- TODO implment as [Either Exception Val] instead of [String]
-    responses :: [String]
-  } deriving (Eq, Show)
 
-{--
-data User = User
-  { userId        :: Int
-  , userFirstName :: String
-  , userLastName  :: String
-  } deriving (Eq, Show)
---}
+type SpielApi = "runFileWithCommands" :> ReqBody '[JSON] SpielCommand :> Post '[JSON] SpielResponse
+  :<|> "file" :> ReqBody '[JSON] SpielFile :> Post '[JSON] SpielResponse
+  :<|> "test" :> Get '[JSON] SpielResponse
 
--- $(deriveJSON defaultOptions ''User)
-$(deriveJSON defaultOptions ''SpielCommand)
-$(deriveJSON defaultOptions ''SpielResponse)
+
+-- defining the api
+api :: Proxy SpielApi
+api = Proxy
+
+
+-- handler for actual requests
+-- performs mapping from endpoints to functions and responses
+-- in order by which they are defined  for the API
+handler :: Server SpielApi
+handler = handleRunFileWithCommands
+  :<|> handleSaveFile
+  :<|> handleTest
+
+
+serverApp :: Application
+serverApp = serve api handler
+
 
 -- setup a command api, for talking to the Repl
 -- represents, 'POST/cmd' w/ a JSON object
@@ -58,71 +54,20 @@ $(deriveJSON defaultOptions ''SpielResponse)
 -- curl --verbose --request POST --header "Content-Type: application/json"
 -- --data '{"file":"examples/example1.bgl","input":"succ(1)"}' http://localhost:8080/spiel
 
--- another example
-{--
-curl --verbose --request POST --header "Content-Type: application/json" --data '{"file":"examples/Notakto.bgl","inputs":["gameLoop(empty)","1","2"]}' http://localhost:8080/spiel
---}
-type SpielApi = "spiel" :> ReqBody '[JSON] SpielCommand :> Post '[JSON] SpielResponse
-  :<|> "spiel" :> Get '[JSON] SpielResponse
+-- > /runFileWithCommands
+-- curl --request POST --header "Content-Type: application/json" --data '{"file":"examples/Notakto.bgl","inputs":["gameLoop(empty)","1","2"]}' http://localhost:8080/runFileWithCommands
 
+-- > /file
+-- curl --request POST --header "Content-Type: application/json" --data '{"fileName":"TEST_FILE.bgl","content":"2 + 3 * 3"}' http://localhost:8080/file
+
+-- > /test
+-- curl http://locahost:8080/test
 startServer :: IO ()
 startServer = do
-  putStrLn "Spiel Backend listening for POST/GET on http://localhost:8080/spiel"
-  (run 8080 serverApp)
-
-serverApp :: Application
-serverApp = serve api handler
-
-api :: Proxy SpielApi
-api = Proxy
-
-handler :: Server SpielApi
-handler = runCommand :<|> handleTestResponse
-
--- runs a command, lifting it into Handler
-runCommand :: SpielCommand -> Handler SpielResponse
-runCommand sc = do
-  (liftIO (_runCommand sc))
-
--- runs command as IO
-_runCommand :: SpielCommand -> IO SpielResponse
-_runCommand (SpielCommand file input) = do
-  Just game <- parseGameFile file
-  let check = success (tc game)
-  -- (Typechecker.Monad.Env, [Either (ValDef, Typechecker.Monad.TypeError) (Name, Type)])
-  -- (Holes, [Either (Value , and associated error (Name, Type))])
-  if check then return (SpielResponse (serverRepl game input)) else return (SpielResponse ["ERR: Could not parse game file!"])
-
--- handles running a command in the repl from the server
-serverRepl :: Game -> [String] -> [String]
-serverRepl g [] = []
-serverRepl g@(Game n i@(BoardDef (szx,szy) p) b vs) (input:ils) = do
-  case parseLine input of
-    Right x -> do
-      case tcexpr (environment i b vs) x of
-        Right t -> do
-          case runWithBuffer (bindings_ (szx, szy) vs) [] x of
-
-            -- TODO program terminated, potentially more data desired
-            Right (x) -> ((show x):(serverRepl g ils))
-
-            -- TODO, board and tape returned, program needs more input
-            Left ((Vboard b'), t') -> ((show b'):(serverRepl g ils))
-
-            -- TODO runtime error encountered
-            Left err -> ((show err):(serverRepl g ils))
-
-        -- TODO typechecker encountered an error in the environment (unlikely not to happen)
-        Left err -> ((show err):(serverRepl g ils))
-
-    -- bad parse
-    Left err -> ((show err):(serverRepl g ils))
-
--- returns a test reponse to the GET test endpoint, to ensure this is running
-handleTestResponse :: Handler SpielResponse
-handleTestResponse = return (SpielResponse ["Spiel is Running!"])
-
-
--- standard test response
-testResponse :: SpielResponse
-testResponse = SpielResponse ["this is from Spiel's API"]
+  let port = 8080
+  putStrLn "Spiel Backend listening for POST/GET with endpoints:"
+  putStrLn "http://localhost:8080/runFileWithCommands (POST)"
+  putStrLn "http://localhost:8080/saveFile (POST)"
+  putStrLn "http://localhost:8080/test (GET)"
+  putStrLn "Ready..."
+  (run port serverApp)

--- a/src/API/Server.hs
+++ b/src/API/Server.hs
@@ -24,8 +24,8 @@ import Servant
 
 
 type SpielApi = "runFileWithCommands" :> ReqBody '[JSON] SpielCommand :> Post '[JSON] SpielResponses
-  :<|> "file" :> ReqBody '[JSON] SpielFile :> Post '[JSON] SpielResponse
-  :<|> "test" :> Get '[JSON] SpielResponse
+  :<|> "file" :> ReqBody '[JSON] SpielFile :> Post '[JSON] SpielResponses
+  :<|> "test" :> Get '[JSON] SpielResponses
 
 
 -- defining the api

--- a/src/API/Test.hs
+++ b/src/API/Test.hs
@@ -10,5 +10,5 @@ import API.JSONData
 import Servant
 
 -- returns a test reponse to the GET test endpoint, to ensure this is running
-handleTest :: Handler SpielResponse
-handleTest = return (SpielOK "Spiel is Running!")
+handleTest :: Handler SpielResponses
+handleTest = return (SpielResponses [(SpielOK "Spiel is Running!")])

--- a/src/API/Test.hs
+++ b/src/API/Test.hs
@@ -1,0 +1,14 @@
+--
+-- Test.hs
+--
+-- Endpoint for testing that the server is running
+--
+
+module API.Test (handleTest) where
+
+import API.JSONData
+import Servant
+
+-- returns a test reponse to the GET test endpoint, to ensure this is running
+handleTest :: Handler SpielResponse
+handleTest = return (SpielResponse ["Spiel is Running!"])

--- a/src/API/Test.hs
+++ b/src/API/Test.hs
@@ -11,4 +11,4 @@ import Servant
 
 -- returns a test reponse to the GET test endpoint, to ensure this is running
 handleTest :: Handler SpielResponse
-handleTest = return (SpielResponse ["Spiel is Running!"])
+handleTest = return (SpielOK "Spiel is Running!")


### PR DESCRIPTION
Closes #42 by adding the **/file** endpoint to allow saving of data into **.bgl** files. Endpoint request is as follows.

```json
{
    "fileName" : "TestFile",
    "content" : "data to write"
}
```

Response format is:
```json
{
    "responses": ["TestFile.bgl written successfully"]
}
```
Note that you don't have to add **.bgl** to the end of the file, it's automatically appended. This will also ensure that the only things we can write to are existing or new **.bgl** files, and not anything else by accident.

Also factors out the API into several other files to make it a bit more clear what's going on structurally. I.e. the server is separate from the recognized kinds of JSONData we can take and return, and each endpoint is given it's own file to keep things organized.