### PR TITLE
Makes Failing Tests Trip CI

### DIFF
--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -1,5 +1,6 @@
 import Test.HUnit
 
+import System.Exit (exitSuccess,exitFailure)
 import ParserTests
 import EvalTests
 
@@ -7,6 +8,11 @@ import EvalTests
 spielTests :: Test
 spielTests = TestList [parserTests,evalTests]
 
+--data Counts = Counts { cases, tried, errors, failures :: Int }
+-- deriving (Eq, Show, Read)
+
 -- run all tests in the suite
-main :: IO Counts
-main = runTestTT spielTests
+main :: IO ()
+main =  do
+  result <- runTestTT spielTests
+  if (errors result) > 0 || (failures result) > 0 then exitFailure else exitSuccess


### PR DESCRIPTION
Implementation of tests for CI didn't return a non-zero exit code when the tests failed. This makes a slight change to the main function, so it will properly exit with a failure code if any tests fail or error out.