### PR TITLE
Adds CORS middleware

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -34,6 +34,8 @@ dependencies:
 - aeson
 - servant-server
 - wai
+- wai-cors
+- wai-extra
 - warp
 - attoparsec
 library:

--- a/src/API/CORSMiddleware.hs
+++ b/src/API/CORSMiddleware.hs
@@ -7,7 +7,7 @@ module API.CORSMiddleware where
 
 import Network.Wai                       (Middleware)
 import Network.Wai.Middleware.AddHeaders (addHeaders)
-import Network.Wai.Middleware.Cors       (CorsResourcePolicy(..), cors)
+import Network.Wai.Middleware.Cors       (CorsResourcePolicy(..), cors, Origin)
 
 -- | @x-csrf-token@ allowance.
 -- The following header will be set: @Access-Control-Allow-Headers: x-csrf-token@.
@@ -17,6 +17,11 @@ allowCsrf = addHeaders [("Access-Control-Allow-Headers", "x-csrf-token,authoriza
 -- | CORS middleware configured with 'appCorsResourcePolicy'.
 corsified :: Middleware
 corsified = cors (const $ Just appCorsResourcePolicy)
+
+
+--unused for the moment
+--allowAll :: Origin
+--allowAll = "http://localhost:3000"
 
 -- | Cors resource policy to be used with 'corsified' middleware.
 --
@@ -31,7 +36,7 @@ appCorsResourcePolicy = CorsResourcePolicy {
   , corsRequestHeaders = ["Authorization", "Content-Type"]
   , corsExposedHeaders = Nothing
   , corsMaxAge         = Nothing
-  , corsVaryOrigin     = False
-  , corsRequireOrigin  = False
-  , corsIgnoreFailures = False
+  , corsVaryOrigin     = True
+  , corsRequireOrigin  = True
+  , corsIgnoreFailures = True
 }

--- a/src/API/CORSMiddleware.hs
+++ b/src/API/CORSMiddleware.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE OverloadedStrings #-}
+--
+-- Based on @https://stackoverflow.com/questions/41399055/haskell-yesod-cors-problems-with-browsers-options-requests-when-doing-post-req
+--
+
+module API.CORSMiddleware where
+
+import Network.Wai                       (Middleware)
+import Network.Wai.Middleware.AddHeaders (addHeaders)
+import Network.Wai.Middleware.Cors       (CorsResourcePolicy(..), cors)
+
+-- | @x-csrf-token@ allowance.
+-- The following header will be set: @Access-Control-Allow-Headers: x-csrf-token@.
+allowCsrf :: Middleware
+allowCsrf = addHeaders [("Access-Control-Allow-Headers", "x-csrf-token,authorization")]
+
+-- | CORS middleware configured with 'appCorsResourcePolicy'.
+corsified :: Middleware
+corsified = cors (const $ Just appCorsResourcePolicy)
+
+-- | Cors resource policy to be used with 'corsified' middleware.
+--
+-- This policy will set the following:
+--
+-- * RequestHeaders: @Content-Type@
+-- * MethodsAllowed: @OPTIONS, GET, PUT, POST@
+appCorsResourcePolicy :: CorsResourcePolicy
+appCorsResourcePolicy = CorsResourcePolicy {
+    corsOrigins        = Nothing
+  , corsMethods        = ["OPTIONS", "GET", "PUT", "POST"]
+  , corsRequestHeaders = ["Authorization", "Content-Type"]
+  , corsExposedHeaders = Nothing
+  , corsMaxAge         = Nothing
+  , corsVaryOrigin     = False
+  , corsRequireOrigin  = False
+  , corsIgnoreFailures = False
+}

--- a/src/API/JSONData.hs
+++ b/src/API/JSONData.hs
@@ -12,6 +12,11 @@ module API.JSONData where
 import Data.Aeson
 import Data.Aeson.TH
 
+-- representation of a request to read a BoGL file
+data SpielRead = SpielRead {
+  path :: String
+} deriving (Eq, Show)
+
 
 -- representation of a file that will be saved by the user
 data SpielFile = SpielFile {
@@ -44,6 +49,7 @@ data SpielResponses = SpielResponses {
 
 
 -- derive JSON for cmd & response
+$(deriveJSON defaultOptions ''SpielRead)
 $(deriveJSON defaultOptions ''SpielFile)
 $(deriveJSON defaultOptions ''SpielCommand)
 $(deriveJSON defaultOptions ''SpielResponse)

--- a/src/API/ReadFile.hs
+++ b/src/API/ReadFile.hs
@@ -1,0 +1,24 @@
+--
+-- ReadFile.hs
+--
+-- API Endpoint that allows reading a .bgl file
+--
+
+module API.ReadFile (handleReadFile) where
+
+import API.JSONData
+import Servant
+import Control.Monad.IO.Class
+
+-- | handles reading a file and returning it's
+-- contents to the requester
+handleReadFile :: SpielRead -> Handler SpielFile
+handleReadFile rf = do
+  (liftIO (_handleReadFile rf))
+
+
+-- internally attempts to read and return a file
+_handleReadFile :: SpielRead -> IO SpielFile
+_handleReadFile (SpielRead fileName) = do
+  contents <- readFile (fileName ++ ".bgl")
+  return (SpielFile fileName contents)

--- a/src/API/Server.hs
+++ b/src/API/Server.hs
@@ -24,9 +24,10 @@ import Network.Wai.Middleware.RequestLogger (logStdoutDev)
 
 
 
-type SpielApi = "runFileWithCommands" :> ReqBody '[JSON] SpielCommand :> Post '[JSON] (Headers '[Header "Access-Control-Allow-Origin" String] SpielResponses)
-    :<|> "file" :> ReqBody '[JSON] SpielFile :> Post '[JSON] (Headers '[Header "Access-Control-Allow-Origin" String] SpielResponses)
-    :<|> "test" :> Get '[JSON] (Headers '[Header "Access-Control-Allow-Origin" String] SpielResponses)
+-- (Headers '[Header "Access-Control-Allow-Origin" String] SpielResponses)
+type SpielApi = "runFileWithCommands" :> ReqBody '[JSON] SpielCommand :> Post '[JSON] SpielResponses
+    :<|> "file" :> ReqBody '[JSON] SpielFile :> Post '[JSON] SpielResponses
+    :<|> "test" :> Get '[JSON] SpielResponses
 
 
 -- defining the api
@@ -43,9 +44,9 @@ spielFrontLocation = "http://localhost:3000"
 -- performs mapping from endpoints to functions and responses
 -- in order by which they are defined  for the API
 handler :: Server SpielApi
-handler = wrapHandleRunFileWithCommands
-  :<|> wrapHandleSaveFile
-  :<|> return (addHeader spielFrontLocation handleTest)
+handler = handleRunFileWithCommands
+  :<|> handleSaveFile
+  :<|> return (handleTest)
 
 
 -- | wraps requests for running a file with give commands


### PR DESCRIPTION
This is just a last minute addition to the server component. There were CORS (Cross-Origin Resource Sharing) limitations. This adds a middleware that allows these requests to take place from the frontend of a different origin.

I did test this out with the server, and all functions work as expected 👍 . We just need to add the calls and functionality on the front-end and we're good to go.

From the browser results can be seen in the inspector for hitting the run button. Just need a place to put them on the page, and need to clean up the response messages a bit.

Making a request to run commands on examples/TicTacToe.bgl:
<img width="562" alt="Screen Shot 2020-03-06 at 15 45 43" src="https://user-images.githubusercontent.com/5070304/76130987-90bf3b80-5fc1-11ea-8828-7b94a152ae51.png">

Results:
<img width="1143" alt="Screen Shot 2020-03-06 at 15 43 50" src="https://user-images.githubusercontent.com/5070304/76130929-5bb2e900-5fc1-11ea-8cc0-31f2981ad569.png">
