### PR TITLE
Properly encodes board to submit to front-end

### DIFF
--- a/src/API/JSONData.hs
+++ b/src/API/JSONData.hs
@@ -11,6 +11,9 @@ module API.JSONData where
 
 import Data.Aeson
 import Data.Aeson.TH
+import Runtime.Serializer
+import Runtime.Values
+import Data.Array
 
 -- representation of a request to read a BoGL file
 data SpielRead = SpielRead {
@@ -63,7 +66,7 @@ data SpielResponse =
 
 instance Show SpielResponse where
   -- shows a board in JSON
-  show (SpielBoard b)                 = show b
+  show (SpielBoard s)                 = show s
   -- indicates that the game is over and a player has won
   show (SpielGameResult gr)           = show gr
   -- shows a type error to the user

--- a/src/API/RunFileWithCommands.hs
+++ b/src/API/RunFileWithCommands.hs
@@ -12,10 +12,11 @@ import Servant
 import Parser.Parser
 import Language.Syntax
 import Language.Types
-import Runtime.Values
 import Typechecker.Typechecker
 import Runtime.Eval
 import Control.Monad.IO.Class
+import Runtime.Serializer
+import Runtime.Values
 
 
 -- runs a file with given commands, lifting it into Handler
@@ -50,7 +51,7 @@ serverRepl g@(Game _ i@(BoardDef (szx,szy) _) b vs) fn (inpt:ils) = do
             Right (val) -> ((SpielValue (show val)):(serverRepl g fn ils))
 
             -- board and tape returned, returns the board for displaying on the frontend
-            Left ((Vboard b'), _) -> ((SpielBoard (show b')):(serverRepl g fn ils)) -- used to be ((Vboard b'), t')
+            Left (bord@(Vboard _), _) -> ((SpielBoard (encodeBoard bord)):(serverRepl g fn ils)) -- used to be ((Vboard b'), t')
 
             -- runtime error encountered
             Left err -> ((SpielRuntimeError (show err)):(serverRepl g fn ils))

--- a/src/Runtime/Serializer.hs
+++ b/src/Runtime/Serializer.hs
@@ -9,11 +9,30 @@
 -- primarily for stateless communication with the Spiel frontend
 --
 
-module Runtime.Serializer where
+module Runtime.Serializer (encodeBoard) where
 
+import Text.JSON.Generic hiding(encode)
 import Parser.Parser
-import Text.JSON.Generic
 import Language.Syntax
+import Data.Aeson
+import Runtime.Values
+import Data.Array
+import Data.Aeson.TH
+import Data.List
+
+encode1DArray :: [((Int,Int),Val)] -> String
+encode1DArray [] = ""
+encode1DArray ((_,val):ls) = "\"" ++ (show val) ++ "\"" ++ (if length ls > 0 then "," else "") ++ (encode1DArray ls)
+
+encode2DArray :: [[((Int, Int), Val)]] -> String
+encode2DArray [] = ""
+encode2DArray (ar:ls) = "[" ++ (encode1DArray ar) ++ "]" ++ (if length ls > 0 then "," else "") ++ (encode2DArray ls)
+
+toGrid x = (groupBy (\x y -> (fst . fst) x == (fst . fst) y) (assocs x))
+
+encodeBoard :: Val -> String
+encodeBoard v@(Vboard b) = "{\"board\": ["++(encode2DArray (toGrid b))++"]}"
+encodeBoard _ = "Cannot encode non-board!"
 
 
 -- encodes the game as a JSON object


### PR DESCRIPTION
Fixes encoding functionality so boards are turned in JSON that can be parsed on the frontend. Produces an ```[[Val]]``` making it fairly easy to parse and display as a grid in the Repl feedback.