### PR TITLE
remove unofficial language features

### DIFF
--- a/src/Language/Syntax.hs
+++ b/src/Language/Syntax.hs
@@ -27,7 +27,6 @@ instance Show (Game a) where
                          ++ show i ++ "\n"
                          ++ intercalate ("\n\n\n") (map show vs)
 
-
 -- | Signatures are a product of name and type.
 data Signature = Sig Name Type
    deriving (Eq)
@@ -44,11 +43,6 @@ instance Show Parlist where
   show (Pars xs) = "(" ++ intercalate (" , ") (xs) ++ ")"
 
 -- | Top level values are signatures paired with either an ordinary 'Equation'
-
-
-
-
-
 data ValDef a = Val Signature (Equation a) a
   | BVal Signature [BoardEq a] a
    deriving (Eq, Generic)
@@ -138,7 +132,6 @@ instance Functor Expr where
   fmap f (S n) = (S n)
   fmap f (I x) = (I x)
 
-
 deAnnotate :: Expr a -> Expr a
 deAnnotate (Annotation a e) = e
 deAnnotate x = x
@@ -146,21 +139,19 @@ deAnnotate x = x
 clearAnn :: Expr a -> Expr ()
 clearAnn = (() <$)
 
-
-
 instance Show (Expr a) where
   show (Annotation _ e) = show e -- can refactor
-  show (HE n) = "?" ++ n
-  show (I i) = show i
-  show (S s) = s
-  show (B b) = show b
-  show (Ref n) = n
-  show (Tuple e) = "(" ++ intercalate " , " (map show e) ++ ")"
-  show (App n es) = n ++ show es
-  show (Binop o e1 e2) = show e1 ++ show o ++ show e2
-  show (Let n e1 e2) = "Let " ++ n ++ " = " ++ show e1 ++ " in " ++ show e2
-  show (If e1 e2 e3) = "If " ++ show e1 ++ " Then " ++ show e2 ++ " Else " ++ show e3
-  show (While c b n e ) = "While " ++ show c ++ " do " ++ show b ++ "(with names, values from wrapper: " ++ show n ++ ", " ++ show e ++ ")" 
+  show (HE n)           = "?" ++ n
+  show (I i)            = show i
+  show (S s)            = s
+  show (B b)            = show b
+  show (Ref n)          = n
+  show (Tuple e)        = "(" ++ intercalate " , " (map show e) ++ ")"
+  show (App n es)       = n ++ show es
+  show (Binop o e1 e2)  = show e1 ++ show o ++ show e2
+  show (Let n e1 e2)    = "let " ++ n ++ " = " ++ show e1 ++ " in " ++ show e2
+  show (If e1 e2 e3)    = "if " ++ show e1 ++ " then " ++ show e2 ++ " else " ++ show e3
+  show (While c b n e ) = "while " ++ show c ++ " do " ++ show b 
 
 -- | Binary operations
 data Op = Plus
@@ -169,11 +160,6 @@ data Op = Plus
         | Div
         | Mod
         | Equiv
-        | Or
-        | And
-        | Less
-        | Xor
-        | Greater
         | Get           -- Gets contents from a position on a board 
    deriving (Eq, Generic)
 
@@ -184,9 +170,4 @@ instance Show Op where
   show Div      = " / "
   show Mod      = " % "
   show Equiv    = " == "
-  show Or       = " or "
-  show And      = " and "
-  show Less     = " < "
-  show Xor      = " xor "
-  show Greater  = " > "
   show Get      = " ! " 

--- a/src/Parser/Parser.hs
+++ b/src/Parser/Parser.hs
@@ -24,7 +24,6 @@ import Data.List
 
 type SrcExpr = Expr Pos
 
-
 -- | State for the parser
 data ParState = PS {
   ctype :: Maybe Type,
@@ -85,16 +84,14 @@ lexer = P.makeTokenParser (haskellStyle {P.reservedNames = ["True", "False",
                                                             "let", "in", "if", "then", "else",
                                                             "while", "do", "game", "type", "Grid", "of", "case", "type"
                                                             ] ++ types,
-                                        P.reservedOpNames = ["=", "*", "==", "-", "/=", "/", "+", ":", "->", "<", "&", "{", "}"]})
-
-
+                                        P.reservedOpNames = ["=", "*", "==", "-", "/=", "/", "+", ":", "->", "{", "}"]})
 
 -- | Operators (might want to fix the order of operations)
 operators = [
              [op "!" (Binop Get) AssocLeft],
              [op "*" (Binop Times) AssocLeft, op "/" (Binop Div) AssocLeft, op "mod" (Binop Mod) AssocLeft],
              [op "+" (Binop Plus) AssocLeft, op "-" (Binop Minus) AssocLeft],
-             [op "==" (Binop Equiv) AssocLeft, op "&&" (Binop And) AssocLeft, op "||" (Binop Or) AssocLeft, op "<" (Binop Less) AssocLeft, op ">" (Binop Greater) AssocLeft]
+             [op "==" (Binop Equiv) AssocLeft]
             ]
 
 -- | Parser for the 'Expr' datatype
@@ -127,12 +124,9 @@ reservedOp = P.reservedOp lexer
 charLiteral = P.charLiteral lexer
 comma = P.comma lexer
 
-
-
 atom :: Parser (Expr SourcePos)
 atom =
   Annotation <$> getPosition <*> atom'
-
 
 -- | Atomic expressions
 atom' :: Parser (Expr SourcePos)
@@ -230,12 +224,8 @@ btype =
   <|>
   reserved "AnySymbol" *> pure AnySymbol
 
-
-
-
 enum :: Parser (S.Set Name)
 enum = reservedOp "{" *> (S.fromList <$> (commaSep1 capIdentifier)) <* reservedOp "}"
-
 
 -- | Extended types: types after the first are restricted to symbols
 xtype :: Parser Xtype
@@ -249,8 +239,6 @@ xtype = (try $ do
   <|>
       xtype'
 
-
-
 xtype' :: Parser Xtype
 xtype' =
   (try $ capIdentifier >>= lookupSyn)
@@ -260,10 +248,6 @@ xtype' =
   (try $ X <$> btype <*> (pure S.empty))
   <|>
   (try $ Tup <$> parens (lexeme ((:) <$> (xtype <* comma) <*> (commaSep1 xtype))))
-
-
-
-
 
 -- |
 --
@@ -334,7 +318,6 @@ board =
 input :: Parser InputDef
 input =
   reserved "type" *> reserved "Input" *> reservedOp "=" *> (InputDef <$> xtype)
-
 
 typesyn = (try $ (((,) <$> (reserved "type" *> new identifier) <*> (reservedOp "=" *> xtype)) >>= addSyn))
 

--- a/src/Runtime/Builtins.hs
+++ b/src/Runtime/Builtins.hs
@@ -25,7 +25,8 @@ builtinT = \i -> [
   ("isFull", Function (Ft (single (X Board S.empty)) (X Booltype S.empty))),
   ("next", Function (Ft (single (X Top (S.fromList ["X", "O"]))) (X Top (S.fromList ["X", "O"])))),
   ("not", Function (Ft (single (X Booltype S.empty)) (X Booltype S.empty))), 
-  ("or", Function (Ft (Tup [X Booltype S.empty, X Booltype S.empty]) (X Booltype S.empty)))
+  ("or", Function (Ft (Tup [X Booltype S.empty, X Booltype S.empty]) (X Booltype S.empty))),
+  ("and", Function (Ft (Tup [X Booltype S.empty, X Booltype S.empty]) (X Booltype S.empty)))
   -- place and inARow should be polymorphic over all types instead of over all symbols.
            ]
 
@@ -38,7 +39,8 @@ builtins = [
   ("inARow", \[Vi i, v, Vboard arr] -> return $ Vb $ inARow arr v i),
   ("next", \[Vs s] -> return $ if s == "X" then Vs "O" else Vs "X"),
   ("not", \[Vb b] -> return $ Vb (not b)),
-  ("or", \[Vb a, Vb b] -> return $ Vb (a || b))
+  ("or", \[Vb a, Vb b] -> return $ Vb (a || b)),
+  ("and", \[Vb a, Vb b] -> return $ Vb (a && b))
   ]
 
 builtinRefs :: [(Name, Eval Val)]

--- a/src/Runtime/Eval.hs
+++ b/src/Runtime/Eval.hs
@@ -17,13 +17,7 @@ import Control.Monad.Writer
 
 import Text.Parsec.Pos
 
-
 import Debug.Trace
-
-
-
-
-
 
 -- | Produce all of the bindings from a list of value definitions. This is done sequentially. Errors are reported as they're found.
 bindings :: (Int, Int) -> [ValDef a] -> Writer [Exception] Env
@@ -58,9 +52,6 @@ updateBoard :: Board -> (Int, Int) -> (BoardEq a) -> Val -> Board
 updateBoard b sz d v = let indices = range ((1,1), sz) in
                               b // zip (filter (posMatches (xpos d) (ypos d)) indices) (repeat v)
 
-
-
-
 -- | Check if a Pos matches a coordinate pair
 posMatches :: Pos -> Pos -> (Int, Int) -> Bool
 posMatches xp yp (x, y) = match xp x && match yp y
@@ -77,10 +68,6 @@ evalBinOp Times l r = evalNumOp (*) l r
 evalBinOp Div l r   = evalNumOp div l r
 evalBinOp Mod l r   = evalNumOp mod l r
 evalBinOp Equiv l r = evalEquiv l r
-evalBinOp Or l r    = evalBoolOp (||) l r
-evalBinOp Less l r  = evalCompareOp (<) l r
-evalBinOp And l r   = evalBoolOp (&&) l r
-evalBinOp Xor l r   = evalBoolOp (/=) l r
 evalBinOp Get l r   = do
                         board <- eval l
                         pos   <- eval r
@@ -96,15 +83,6 @@ evalEquiv l r = do
                   v2 <- eval r
                   return $ Vb (v1 == v2)
 
--- | evaluates comparison operations (except for ==)
-evalCompareOp :: (Int -> Int -> Bool) -> (Expr a) -> (Expr a) -> Eval Val
-evalCompareOp f l r = do
-                     v1 <- eval l
-                     v2 <- eval r
-                     case (v1, v2) of
-                        (Vi l', Vi r') -> return (Vb (f l' r'))
-                        _ -> return $ Err $ "Could not compare " ++ (show l) ++ " to " ++ (show r)
-
 -- | evaluates numerical operations
 evalNumOp :: (Int -> Int -> Int) -> (Expr a) -> (Expr a) -> Eval Val
 evalNumOp f l r = do
@@ -113,16 +91,6 @@ evalNumOp f l r = do
                      case (v1, v2) of
                         (Vi l', Vi r') -> return (Vi (f l' r'))
                         _ -> return $ Err $ "Could not do numerical operation on " ++ (show l) ++ " to " ++ (show r)
-
--- | evaluates boolean operations
-evalBoolOp :: (Bool -> Bool -> Bool) -> (Expr a) -> (Expr a) -> Eval Val
-evalBoolOp f l r = do
-                     v1 <- eval l
-                     v2 <- eval r
-                     case (v1, v2) of
-                        (Vb l', Vb r') -> return (Vb (f l' r'))
-                        _ -> return $ Err $ "Could not do boolean operation on " ++ (show l) ++ " to " ++ (show r)
-
 
 eval :: (Expr a) -> Eval Val
 eval (Annotation a e) = eval e

--- a/src/Typechecker/Typechecker.hs
+++ b/src/Typechecker/Typechecker.hs
@@ -119,12 +119,7 @@ exprtype (Binop x e1 e2) = do
   case (t') of
     (X Itype s1) | S.null s1 -> if x `elem` [Plus, Minus, Times, Div, Mod]
                                               then t Itype
-                                              else if x `elem` [Less, Greater]
-                                                   then t Booltype
-                                                   else badop x (Plain t1) (Plain t2)
-    (X Booltype s1) -> if x `elem` [And, Or, Xor] && S.null s1
-                                                    then t Booltype
-                                                    else badop x (Plain t1) (Plain t2)
+                                              else badop x (Plain t1) (Plain t2)
     _ -> badop x (Plain t1) (Plain t2)
 exprtype (If e1 e2 e3) = do
   t1 <- exprtype e1

--- a/test/EvalTests.hs
+++ b/test/EvalTests.hs
@@ -13,34 +13,19 @@ import Runtime.Monad
 import Runtime.Values
 
 evalTests :: Test
-evalTests = TestList [testEvalBinOps,
+evalTests = TestList [
   testEvalEquiv,
-  testEvalLess,
   testEvalPlusMinusTimes,
   testBadTypesPlus,
   testEval2,
   testEvalTuple,
   testEvalLetRef]
 
--- Evaluate an expression in the Eval Monad
-testEvalBinOps :: Test
-testEvalBinOps = TestCase (
-  assertEqual "Evaluate False w/ Binop that evals to false"
-  (Right (Vb True))
-  (evalTest (eval (Binop Equiv (B False) (Binop And (B True) (B False))))))
-
-
 testEvalEquiv :: Test
 testEvalEquiv = TestCase (
   assertEqual "Test equiv in eval"
   (Right (Vb False))
   (evalTest (eval (Binop Equiv (I 3) (I 4)))))
-
-testEvalLess :: Test
-testEvalLess = TestCase (
-  assertEqual "Test less in eval"
-  (Right (Vb True))
-  (evalTest (eval (Binop Less (I 3) (I 4)))))
 
 testEvalPlusMinusTimes :: Test
 testEvalPlusMinusTimes = TestCase (


### PR DESCRIPTION
Martin had mentioned that everything but arithmetic operators should be treated as functions. I removed all non-arithmetic operators that are not in the official syntax, we can define them in the prelude if needed (with the added benefit of allowing students to see how you can build more complicated operators from the basics). 