### PR TITLE
Adds /runCode Endpoint and Port Setting

### DIFF
--- a/serverApp/ServerMain.hs
+++ b/serverApp/ServerMain.hs
@@ -1,7 +1,19 @@
+--
+-- ServerMain.hs
+-- Main entry point for the backend language server
+--
+
 module Main where
+
 import API.Server
+import System.Environment
 
 -- boots up the server by default
 main :: IO ()
 main = do
-  startServer
+  -- get and check if 1st arg is an int
+  args <- getArgs
+  case length args of
+    0     -> startServer 8080      -- default to port 8080
+    1     -> startServer (read (head args)) -- bind to 1st port # instad
+    _     -> putStrLn "\n\nError: Can only pass one arg!\nUsage\n./spielserver\n./spielserver 8080\n\n"

--- a/src/API/JSONData.hs
+++ b/src/API/JSONData.hs
@@ -54,6 +54,8 @@ instance FromJSON Val where
         Left err -> fail "failed to parse..." -- FIXME
       Left err -> fail "failed to parse..."
   parseJSON _ = fail "FAILURE?"
+
+
 -- | representation of input to the repl, from the user
 data SpielCommand = SpielCommand {
     prelude :: String,
@@ -62,14 +64,17 @@ data SpielCommand = SpielCommand {
     buffer :: [Val]
   } deriving (Eq, Show, Generic)
 
+
 instance ToJSON SpielCommand
 instance FromJSON SpielCommand
+
 
 -- | for errors
 type Message = String
 type LineNum = Int
 type ColNum  = Int
 type FileName= String
+
 
 -- | Represents possible response categories from the server
 -- These are then parsed accordingly on the front-end
@@ -95,22 +100,20 @@ instance ToJSON SpielResponse where
 
 instance Show SpielResponse where
   -- shows a board in JSON
-  show (SpielPrompt s)                 = show s
+  show (SpielPrompt s)                  = show s
   -- indicates that the game is over and a player has won
-  show (SpielGameResult gr)           = show gr
+  show (SpielGameResult gr)             = show gr
   -- shows a parse error to the user
-  show (SpielParseError ln cn fn m)   = "{tag: \"parseError\", lineNum: "++show ln++", colNum: "++ show cn ++", fileName: \""++ fn ++"\", message: \""++ m ++"\"}"
+  show (SpielParseError ln cn fn m)     = "{tag: \"parseError\", lineNum: "++show ln++", colNum: "++ show cn ++", fileName: \""++ fn ++"\", message: \""++ m ++"\"}"
   -- shows a runtime error in spiel
   -- show a spiel value
-  show (SpielValue m)                 = show m
+  show (SpielValue m)                   = show m
   -- show a typed hole
   -- TODO this one needs cleaning up
-  show (SpielTypeHole m x y)              = show m
+  show (SpielTypeHole m x y)            = show m
   -- show a fallback error, such as reading a bad-file
-  show (SpielError m)                 = show m
+  show (SpielError m)                   = show m
 
 
 
 type SpielResponses = [SpielResponse]
-
-

--- a/src/API/Run.hs
+++ b/src/API/Run.hs
@@ -8,25 +8,21 @@
 module API.Run (_runFileWithCommands) where
 
 import API.JSONData
-import Servant
-import Data.Bifunctor
 import Parser.Parser
 import Language.Syntax
 import Language.Types
 import Text.Parsec.Pos
 import Text.Parsec (errorPos)
-import Text.Parsec.Error
 
 import Typechecker.Typechecker
 import Runtime.Eval
-import Control.Monad.IO.Class
 import Runtime.Values
 
 
 -- |Runs this code under the IO monad
 _runFileWithCommands :: SpielCommand -> IO SpielResponses
-_runFileWithCommands (SpielCommand prelude gameFile inpt buf) = do
-  parsed <- parsePreludeAndGameFiles prelude gameFile
+_runFileWithCommands (SpielCommand _prelude gameFile inpt buf) = do
+  parsed <- parsePreludeAndGameFiles _prelude gameFile
   case parsed of
     Right game -> do
       let checked = tc game
@@ -44,7 +40,7 @@ _runFileWithCommands (SpielCommand prelude gameFile inpt buf) = do
 
 -- |Handles running a command in the repl from the server
 serverRepl :: (Game SourcePos) -> String -> String -> [Val] -> SpielResponse
-serverRepl g@(Game _ i@(BoardDef (szx,szy) _) b vs) fn inpt buf = do
+serverRepl (Game _ i@(BoardDef (szx,szy) _) b vs) fn inpt buf = do
   case parseLine inpt of
     Right x -> do
       case tcexpr (environment i b vs) x of
@@ -55,7 +51,7 @@ serverRepl g@(Game _ i@(BoardDef (szx,szy) _) b vs) fn inpt buf = do
             Right (val) -> SpielValue val
 
             -- board and tape returned, returns the board for displaying on the frontend
-            Left (v, t) -> SpielPrompt v
+            Left (v, _) -> SpielPrompt v
 
             -- runtime error encountered
             Left err -> SpielRuntimeError (show err)

--- a/src/API/Run.hs
+++ b/src/API/Run.hs
@@ -1,0 +1,70 @@
+--
+-- Run.hs
+--
+-- Holds utility run code for both /runCmds and /runCode.
+-- Holds the routines for parsing and interpreting a BoGL Prelude and Game file
+--
+
+module API.Run (_runFileWithCommands) where
+
+import API.JSONData
+import Servant
+import Data.Bifunctor
+import Parser.Parser
+import Language.Syntax
+import Language.Types
+import Text.Parsec.Pos
+import Text.Parsec (errorPos)
+import Text.Parsec.Error
+
+import Typechecker.Typechecker
+import Runtime.Eval
+import Control.Monad.IO.Class
+import Runtime.Values
+
+
+-- |Runs this code under the IO monad
+_runFileWithCommands :: SpielCommand -> IO SpielResponses
+_runFileWithCommands (SpielCommand prelude gameFile inpt buf) = do
+  parsed <- parsePreludeAndGameFiles prelude gameFile
+  case parsed of
+    Right game -> do
+      let checked = tc game
+      if success checked
+        then return $ [SpielTypes (rtypes checked), (serverRepl game gameFile inpt buf)]
+        else return $ SpielTypes (rtypes checked) : map (SpielTypeError . snd) (errors checked)
+
+    Left err -> do
+      let position = errorPos err
+          l = sourceLine position
+          c = sourceColumn position
+          in
+        return $ [SpielParseError l c gameFile (show err)]
+
+
+-- |Handles running a command in the repl from the server
+serverRepl :: (Game SourcePos) -> String -> String -> [Val] -> SpielResponse
+serverRepl g@(Game _ i@(BoardDef (szx,szy) _) b vs) fn inpt buf = do
+  case parseLine inpt of
+    Right x -> do
+      case tcexpr (environment i b vs) x of
+        Right _ -> do -- Right t
+          case runWithBuffer (bindings_ (szx, szy) vs) buf x of
+
+            -- program terminated normally with a value
+            Right (val) -> SpielValue val
+
+            -- board and tape returned, returns the board for displaying on the frontend
+            Left (v, t) -> SpielPrompt v
+
+            -- runtime error encountered
+            Left err -> SpielRuntimeError (show err)
+
+        -- typechecker encountered an error in the expression
+        Left err -> (SpielTypeError err)
+    -- bad parse
+    Left err ->
+      let position = errorPos err
+          l = sourceLine position
+          c = sourceColumn position in
+      (SpielParseError l c fn (show err))

--- a/src/API/RunCode.hs
+++ b/src/API/RunCode.hs
@@ -10,19 +10,9 @@ module API.RunCode (handleRunCode) where
 import API.Run
 import API.JSONData
 import Servant
-import Data.Bifunctor
-import Parser.Parser
-import Language.Syntax
-import Language.Types
-import Text.Parsec.Pos
-import Text.Parsec (errorPos)
-import Text.Parsec.Error
 import Control.Exception hiding (Handler)
 
-import Typechecker.Typechecker
-import Runtime.Eval
 import Control.Monad.IO.Class
-import Runtime.Values
 
 
 -- |Runs literal code, lifting it into Handler
@@ -30,7 +20,7 @@ import Runtime.Values
 -- Once these both succeed, the new temporary files are parsed
 -- , and the response is returned
 handleRunCode :: SpielCommand -> Handler SpielResponses
-handleRunCode sc@(SpielCommand preludeContents gameFileContents inpt buf) = liftIO $ do
+handleRunCode (SpielCommand preludeContents gameFileContents inpt buf) = liftIO $ do
   -- attempt to write temporary prelude & game files
   success1 <- try $ writeFile ("tmp_prelude.bgl") preludeContents :: IO (Either IOException ())
   success2 <- try $ writeFile ("tmp_tmp.bgl") gameFileContents :: IO (Either IOException ())

--- a/src/API/RunCode.hs
+++ b/src/API/RunCode.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE OverloadedStrings #-}
+--
+-- RunCode.hs
+--
+-- Endpoint for running literal BoGL code without a file (for the Prelude as well)
+--
+
+module API.RunCode (handleRunCode) where
+
+import API.Run
+import API.JSONData
+import Servant
+import Data.Bifunctor
+import Parser.Parser
+import Language.Syntax
+import Language.Types
+import Text.Parsec.Pos
+import Text.Parsec (errorPos)
+import Text.Parsec.Error
+import Control.Exception hiding (Handler)
+
+import Typechecker.Typechecker
+import Runtime.Eval
+import Control.Monad.IO.Class
+import Runtime.Values
+
+
+-- |Runs literal code, lifting it into Handler
+-- Creates a temporary tmp_prelude.bgl and tmp_tmp.bgl to write contents into.
+-- Once these both succeed, the new temporary files are parsed
+-- , and the response is returned
+handleRunCode :: SpielCommand -> Handler SpielResponses
+handleRunCode sc@(SpielCommand preludeContents gameFileContents inpt buf) = liftIO $ do
+  -- attempt to write temporary prelude & game files
+  success1 <- try $ writeFile ("tmp_prelude.bgl") preludeContents :: IO (Either IOException ())
+  success2 <- try $ writeFile ("tmp_tmp.bgl") gameFileContents :: IO (Either IOException ())
+  -- verify they both succeeded before proceeding
+  case success1 of
+    Right _ -> case success2 of
+                  Right _ -> (liftIO (_runFileWithCommands (SpielCommand "tmp_prelude.bgl" "tmp_tmp.bgl" inpt buf))) -- valid, calls API.Run._runFileWithCommands to interpret these files
+                  Left e2  -> return [(Log ("Game File Exception: " ++ displayException e2))]
+    Left e1 -> return [(Log ("Prelude Exception: " ++ displayException e1))]

--- a/src/API/RunFileWithCommands.hs
+++ b/src/API/RunFileWithCommands.hs
@@ -11,18 +11,7 @@ module API.RunFileWithCommands (handleRunFileWithCommands) where
 import API.Run
 import API.JSONData
 import Servant
-import Data.Bifunctor
-import Parser.Parser
-import Language.Syntax
-import Language.Types
-import Text.Parsec.Pos
-import Text.Parsec (errorPos)
-import Text.Parsec.Error
-
-import Typechecker.Typechecker
-import Runtime.Eval
 import Control.Monad.IO.Class
-import Runtime.Values
 
 
 -- |Runs a file with given commands, lifting it into Handler

--- a/src/API/RunFileWithCommands.hs
+++ b/src/API/RunFileWithCommands.hs
@@ -2,12 +2,13 @@
 --
 -- RunFileWithCommands.hs
 --
--- Endpoint for running a given file with a list of commands
+-- Endpoint for running a given file with a command, input buffer,
 -- and returning a list of responses
 --
 
 module API.RunFileWithCommands (handleRunFileWithCommands) where
 
+import API.Run
 import API.JSONData
 import Servant
 import Data.Bifunctor
@@ -18,61 +19,14 @@ import Text.Parsec.Pos
 import Text.Parsec (errorPos)
 import Text.Parsec.Error
 
-
-
-
 import Typechecker.Typechecker
 import Runtime.Eval
 import Control.Monad.IO.Class
 import Runtime.Values
 
 
--- runs a file with given commands, lifting it into Handler
+-- |Runs a file with given commands, lifting it into Handler
 handleRunFileWithCommands :: SpielCommand -> Handler SpielResponses
 handleRunFileWithCommands sc = do
+  -- calls API.Run._runFileWithCommands to interpret these files
   (liftIO (_runFileWithCommands sc))
-
--- runs command as IO
-_runFileWithCommands :: SpielCommand -> IO SpielResponses
-_runFileWithCommands (SpielCommand prelude gameFile inpt buf) = do
-  parsed <- parsePreludeAndGameFiles prelude gameFile
-  case parsed of
-    Right game -> do
-      let checked = tc game
-      if success checked
-        then return $ [SpielTypes (rtypes checked), (serverRepl game gameFile inpt buf)]
-        else return $ SpielTypes (rtypes checked) : map (SpielTypeError . snd) (errors checked)
-
-    Left err -> do
-      let position = errorPos err
-          l = sourceLine position
-          c = sourceColumn position
-          in 
-        return $ [SpielParseError l c gameFile (show err)]
-
--- handles running a command in the repl from the server
-serverRepl :: (Game SourcePos) -> String -> String -> [Val] -> SpielResponse
-serverRepl g@(Game _ i@(BoardDef (szx,szy) _) b vs) fn inpt buf = do
-  case parseLine inpt of
-    Right x -> do
-      case tcexpr (environment i b vs) x of
-        Right _ -> do -- Right t
-          case runWithBuffer (bindings_ (szx, szy) vs) buf x of
-
-            -- program terminated normally with a value
-            Right (val) -> SpielValue val
-
-            -- board and tape returned, returns the board for displaying on the frontend
-            Left (v, t) -> SpielPrompt v
-
-            -- runtime error encountered
-            Left err -> SpielRuntimeError (show err)
-
-        -- typechecker encountered an error in the expression
-        Left err -> (SpielTypeError err)
-    -- bad parse
-    Left err ->
-      let position = errorPos err
-          l = sourceLine position
-          c = sourceColumn position in 
-      (SpielParseError l c fn (show err))

--- a/src/API/SaveFile.hs
+++ b/src/API/SaveFile.hs
@@ -13,11 +13,11 @@ import Servant
 import Control.Monad.IO.Class
 import Control.Exception hiding (Handler)
 
--- TODO Change SpielResponse to SpielOK/SpielError
 
+-- |Handles saving a file to the server space
 handleSaveFile :: SpielFile -> Handler SpielResponses
 handleSaveFile (SpielFile fn contents) = liftIO $ do
-    -- TODO needs to check if this file was successfully written, rather than just assuming it is (@montymxb)
+    -- verifies the file is actually able to be written to
     success <- try $ writeFile (fn) contents :: IO (Either IOException ())
     case success of
       Right _ -> return [(Log (fn ++ " written successfully"))]

--- a/src/API/Server.hs
+++ b/src/API/Server.hs
@@ -71,7 +71,7 @@ curl --verbose --request POST --header "Content-Type: application/json" --data '
 curl --verbose --request POST --header "Content-Type: application/json" --data '{"fileName":"TEST_FILE","content":"2 + 3 * 3"}' http://localhost:8080/save
 
 > /runCode
-curl --verbose --request POST --header "Content-Type: application/json" --data '{"file":"...LITERAL FILE CONTENTS HERE...","input":2","buffer":[],"prelude":"Prelude.bglp"}' http://localhost:8080/runCmds
+curl --verbose --request POST --header "Content-Type: application/json" --data '{"file":"game Test\ntype Board = Array (10,10) of Int\ntype Input = Int\nhello : Int\nhello = 32","prelude":"testVal : Int\ntestVal = 2","input":"hello","buffer":[]}' http://localhost:8080/runCmds
 
 > /read
 curl --verbose --request POST --header "Content-Type: application/json" --data '{"path":"examples/TicTacToe"}' http://localhost:8080/read

--- a/src/Parser/Parser.hs
+++ b/src/Parser/Parser.hs
@@ -353,7 +353,7 @@ parsePreludeAndGameFiles p f = do
   exists <- doesFileExist p
   prel <- if exists
             then Parser.Parser.parseFromFile (many decl) p
-            else return $ fail "Prelude.bglp does not exist"
+            else return $ fail (p++" does not exist")
   case prel of
    Right x -> Parser.Parser.parseFromFile (game (catMaybes x)) f
    Left err -> return $ Left err


### PR DESCRIPTION
This adds a new endpoint `/runCode` to allow running literal BoGL code for a prelude and a game file, without the need to read from a file. 

This uses a lot of the mechanics of the existing `/runCmds` endpoint, and as such it internally generates **tmp_prelude.bgl** and **tmp_tmp.bgl**, files that just created for the purpose of feeding something into the interpreter. I factored out the common functionality between the two into **src/API/Run.hs**, so they both do exactly the same thing once they have files ready to be parsed.

To keep things simple this endpoint uses the exact same format as `/runCmds'. The only difference is that `file` should take the literal game file contents, and `prelude` should take the literal prelude contents; so no file names are passed here. The input and buffer are the same as well.

I also took the liberty of adding in the ability to set a custom port for the `startServer` command (and thus the **spielserver** binary as well). Running without any command line args does the same as it's always done, just binds to port 8080 per usual. Passing in a port # as the only command line arg will attempt to bind to that port instead. Passing any more arguments will give a little error message and a couple usage examples.

Also also, cleans up some comments and code alignment in some of the nearby files.