### PR TITLE
Allow Comments at Beginning of Prelude & Parse Code Directly

### DIFF
--- a/examples/Prelude.bglp
+++ b/examples/Prelude.bglp
@@ -1,2 +1,7 @@
+--
+-- Prelude.bglp
+-- A prelude is automatically loaded in advance of loading a Game file.
+-- This file includes definitions that can be used in the Game file.
+--
 helloFromPrelude : Int
 helloFromPrelude = 100

--- a/src/API/Run.hs
+++ b/src/API/Run.hs
@@ -5,7 +5,7 @@
 -- Holds the routines for parsing and interpreting a BoGL Prelude and Game file
 --
 
-module API.Run (_runFileWithCommands) where
+module API.Run (_runFileWithCommands,_runCodeWithCommands) where
 
 import API.JSONData
 import Parser.Parser
@@ -13,23 +13,38 @@ import Language.Syntax
 import Language.Types
 import Text.Parsec.Pos
 import Text.Parsec (errorPos)
+import Text.Parsec.Error
 
 import Typechecker.Typechecker
 import Runtime.Eval
 import Runtime.Values
 
 
--- |Runs this code under the IO monad
+-- | Runs BoGL code from a file with the given commands
 _runFileWithCommands :: SpielCommand -> IO SpielResponses
-_runFileWithCommands (SpielCommand _prelude gameFile inpt buf) = do
-  parsed <- parsePreludeAndGameFiles _prelude gameFile
-  case parsed of
+_runFileWithCommands sc@(SpielCommand _prelude gameFile _ _) =
+  _handleParsed sc $ parsePreludeAndGameFiles _prelude gameFile
+
+
+-- | Runs BoGL code from raw text with the given commands
+-- Similar to the above '_runFileWithCommands', but instead
+-- utilizes parsePreludeAndGameText to parse the code directly,
+-- without reading it from a file first
+_runCodeWithCommands :: SpielCommand -> IO SpielResponses
+_runCodeWithCommands sc@(SpielCommand _prelude gameFile _ _) =
+  _handleParsed sc $ parsePreludeAndGameText _prelude gameFile
+
+
+-- | Handles result of parsing a prelude and game
+_handleParsed :: SpielCommand -> IO (Either ParseError (Game SourcePos)) -> IO SpielResponses
+_handleParsed (SpielCommand _ gameFile inpt buf) parsed = do
+  pparsed <- parsed
+  case pparsed of
     Right game -> do
       let checked = tc game
       if success checked
         then return $ [SpielTypes (rtypes checked), (serverRepl game gameFile inpt buf)]
         else return $ SpielTypes (rtypes checked) : map (SpielTypeError . snd) (errors checked)
-
     Left err -> do
       let position = errorPos err
           l = sourceLine position

--- a/src/API/RunCode.hs
+++ b/src/API/RunCode.hs
@@ -10,23 +10,14 @@ module API.RunCode (handleRunCode) where
 import API.Run
 import API.JSONData
 import Servant
-import Control.Exception hiding (Handler)
 
 import Control.Monad.IO.Class
 
 
--- |Runs literal code, lifting it into Handler
+-- | Runs literal code, lifting it into Handler
 -- Creates a temporary tmp_prelude.bgl and tmp_tmp.bgl to write contents into.
 -- Once these both succeed, the new temporary files are parsed
 -- , and the response is returned
 handleRunCode :: SpielCommand -> Handler SpielResponses
-handleRunCode (SpielCommand preludeContents gameFileContents inpt buf) = liftIO $ do
-  -- attempt to write temporary prelude & game files
-  success1 <- try $ writeFile ("tmp_prelude.bgl") preludeContents :: IO (Either IOException ())
-  success2 <- try $ writeFile ("tmp_tmp.bgl") gameFileContents :: IO (Either IOException ())
-  -- verify they both succeeded before proceeding
-  case success1 of
-    Right _ -> case success2 of
-                  Right _ -> (liftIO (_runFileWithCommands (SpielCommand "tmp_prelude.bgl" "tmp_tmp.bgl" inpt buf))) -- valid, calls API.Run._runFileWithCommands to interpret these files
-                  Left e2  -> return [(Log ("Game File Exception: " ++ displayException e2))]
-    Left e1 -> return [(Log ("Prelude Exception: " ++ displayException e1))]
+-- calls API.Run._runCodeWithCommands to interpret this raw BoGL code
+handleRunCode sc = liftIO (_runCodeWithCommands sc)

--- a/src/Parser/Parser.hs
+++ b/src/Parser/Parser.hs
@@ -352,7 +352,7 @@ parsePreludeAndGameFiles :: String -> String -> IO (Either ParseError (Game Sour
 parsePreludeAndGameFiles p f = do
   exists <- doesFileExist p
   prel <- if exists
-            then Parser.Parser.parseFromFile (many decl) p
+            then Parser.Parser.parseFromFile (whiteSpace *> many decl) p
             else return $ fail (p++" does not exist")
   case prel of
    Right x -> Parser.Parser.parseFromFile (game (catMaybes x)) f

--- a/src/Parser/Parser.hs
+++ b/src/Parser/Parser.hs
@@ -1,6 +1,6 @@
 -- | Parser for BOGL
 
-module Parser.Parser (parseLine, parseGameFile, parsePreludeAndGameFiles, expr, isLeft, parseAll, valdef, xtype, boardeqn, equation, Parser) where
+module Parser.Parser (parseLine, parseGameFile, parsePreludeAndGameFiles, expr, isLeft, parseAll, valdef, xtype, boardeqn, equation, prelude, Parser) where
 
 import Parser.ParseError
 import Language.Syntax hiding (input, board)
@@ -325,6 +325,10 @@ input =
 
 typesyn = (try $ (((,) <$> (reserved "type" *> new identifier) <*> (reservedOp "=" *> xtype)) >>= addSyn))
 
+-- | Prelude definition
+prelude :: Parser([(Maybe (ValDef SourcePos))])
+prelude = whiteSpace *> many decl
+
 -- | Game definition
 game :: [ValDef SourcePos] -> Parser (Game SourcePos)
 game vs =
@@ -352,7 +356,7 @@ parsePreludeAndGameFiles :: String -> String -> IO (Either ParseError (Game Sour
 parsePreludeAndGameFiles p f = do
   exists <- doesFileExist p
   prel <- if exists
-            then Parser.Parser.parseFromFile (whiteSpace *> many decl) p
+            then Parser.Parser.parseFromFile prelude p
             else return $ fail (p++" does not exist")
   case prel of
    Right x -> Parser.Parser.parseFromFile (game (catMaybes x)) f

--- a/test/ParserTests.hs
+++ b/test/ParserTests.hs
@@ -25,7 +25,8 @@ parserTests = TestList [
   testNoRepeatedParamNames,
   testNoRepeatedMetaVars,
   testPreludeStartingWhitespace,
-  testPreludeNoStartingWhitespace
+  testPreludeNoStartingWhitespace,
+  testParseRawPreludeAndGamefile
   ]
 
 --
@@ -148,7 +149,7 @@ testPreludeStartingWhitespace :: Test
 testPreludeStartingWhitespace = TestCase $
    assertEqual "Test fail on prelude w/ comment at the start"
    True
-   (isRight $ parseAll prelude "" prelude_with_comment)
+   (isRight $ parsePreludeFromText prelude_with_comment)
 
 -- | Prelude w/out a comment
 prelude_no_comment :: String
@@ -159,4 +160,35 @@ testPreludeNoStartingWhitespace :: Test
 testPreludeNoStartingWhitespace = TestCase $
    assertEqual "Test fail on prelude w/out whitespace"
    True
-   (isRight $ parseAll prelude "" prelude_no_comment)
+   (isRight $ parsePreludeFromText prelude_no_comment)
+
+
+-- | Raw prelude code for the test below
+rawPrelude :: String
+rawPrelude = "--a prelude\ntestDecl : Int\ntestDecl = 901"
+-- | Raw prelude code for the test below
+rawGamecode :: String
+rawGamecode = "-- a raw gamefile to parse\n\
+\game Gamefile\n\
+\--setting up the type of the board\n\
+\type Board = Array(3,3) of Int\n\
+\--setting up the input type\n\
+\type Input = Int\n\
+\--setting up a type for testing\n\
+\type TestType = {A,B}\n\
+\--setting up a testing function\n\
+\testFunc : TestType -> TestType\n\
+\testFunc(t) = if t == A then B else A\n\
+\"
+
+-- | Tests parsing a raw prelude and game file from text,
+-- without using a file inbetween. This is used for the
+-- /runCode endpoint
+testParseRawPreludeAndGamefile :: Test
+testParseRawPreludeAndGamefile = TestCase $
+  assertEqual "Test unable to parse raw prelude and gamefile text"
+  True
+  (case parsePreludeFromText rawPrelude of
+    Right valdefs -> isRight $ parseGameFromText rawGamecode valdefs
+    Left err      -> False
+  )


### PR DESCRIPTION
Closes #80. Updates the Parser to allow whitespace before the declarations in the prelude. The declarations themselves already allow whitespace inbetween themselves, but this makes it so comments at the top are valid now.