### PR TITLE
Fix for Similarly Named Back-to-Back Board Decls

### DIFF
--- a/src/Parser/Parser.hs
+++ b/src/Parser/Parser.hs
@@ -1,6 +1,6 @@
 -- | Parser for BOGL
 
-module Parser.Parser (parseLine, parseGameFile, parsePreludeAndGameFiles, expr, isLeft, parseAll, valdef, xtype, boardeqn, equation, Parser) where
+module Parser.Parser (parseLine, parseGameFile, parsePreludeAndGameFiles, expr, isLeft, parseAll, valdef, xtype, boardeqn, equation, decl, typesyn, Parser) where
 
 import Parser.ParseError
 import Language.Syntax hiding (input, board)
@@ -200,7 +200,7 @@ position =
 -- | Board equations
 boardeqn :: String -> Parser (BoardEq SourcePos)
 boardeqn n = do
-   name <- string n <* (lexeme ((lexeme (char '!')) *> char '('))
+   name <- try(string n <* (lexeme ((lexeme (char '!')) *> char '(')))
    xpos <- lexeme position <* lexeme comma
    ypos <- lexeme position <* (lexeme (char ')') <* reservedOp "=")
    case (xpos, ypos) of

--- a/test/ParserTests.hs
+++ b/test/ParserTests.hs
@@ -10,9 +10,10 @@ import Language.Syntax
 import Language.Types
 import qualified Data.Set as S
 import Text.Parsec.Error
-import System.Directory 
-import System.FilePath  
+import System.Directory
+import System.FilePath
 import Data.Either
+import Text.Parsec
 --
 -- exported tests for the Parser
 --
@@ -23,8 +24,13 @@ parserTests = TestList [
   testCheckUpdatedBoard,
   testCheckUpdatedBoard2,
   testRejectBadExprAfterSuccessefulParse,
+  testParseShortDecl,
+  testParseBoardDecl,
+  testParseTypeSynAndDecl,
   testNoRepeatedParamNames,
-  testNoRepeatedMetaVars
+  testNoRepeatedMetaVars,
+  testDoubleBoardDeclarations,
+  testInvalidBoardDeclaration
   ]
 
 --
@@ -79,57 +85,110 @@ testRejectBadExprAfterSuccessefulParse = TestCase (
   True
   (isLeft $ parseLine' expr "40 + 2life,the universe, and everything"))
 
-{-
--- |
-ex1 :: String
-ex1 = "isValid : (Board, Position) -> Bool\n  isValid(b,p) = if b(p) == Empty then True else False"
-
+{-- (vestige from old tests)
 ex2 = "outcome : (Board,Player) -> Player|Tie \
 \ outcome(b,p) = if inARow(3,A,b) then A else \
                 \ if inARow(3,B,b) then B else \
                 \ if isFull(b)     then Tie"
 --}
 
--- testing long expression
-{-
-testParseLongExpr :: Test
-testParseLongExpr = TestCase (
-  assertEqual "Testing parsing of long expression"
+-- | Hello Int declaration
+ex0 :: String
+ex0 = "hello : Int\nhello = 24"
+
+-- |Tests parsing a simple declaration
+testParseShortDecl :: Test
+testParseShortDecl = TestCase (
+  assertEqual("Testing parsing of a short declaration")
   True
+  (isRight $ parseAll valdef "" ex0)
+  )
+
+-- | Simple board decl
+ex1 :: String
+ex1 = "b : Board\nb!(x,y)=0\nb!(1,1)=1"
+
+-- |Tests parsing a board decl
+testParseBoardDecl :: Test
+testParseBoardDecl = TestCase (
+  assertEqual "Testing parsing of board declaration"
+  True
+  (isRight $ parseAll valdef "" ex1)
+  )
+
+-- | type syn followed by var decl
+ex4 :: String
+ex4 = "type TestType = {AnotherType}\ntestThis : TestType\ntestThis = AnotherType"
+
+-- |Tests parsing a type declaration followed by variable declaration
+testParseTypeSynAndDecl :: Test
+testParseTypeSynAndDecl = TestCase (
+  assertEqual("Testing parsing of a type synononym followed by a declaration")
+  True
+  (isRight $ parseAll (typesyn *> many decl) "" ex4)
+  )
+
+  {-- (vestige from old tests)
   (() <$ parseAll valdef "" ex1 ==
     Right (Val (Sig "isValid" (Function
       (Ft (Tup [X Board S.empty, X Position S.empty]) (X Booltype S.empty))
     )) (Feq "isValid" (Pars ["b", "p"])
     (If (Binop Equiv (App "b" [Ref "p"]) (S "Empty")) (B True) (B False))) ())))
--} -- parsing is a nightmare with annotations...
+    --}
+-- parsing is a nightmare with annotations...
 
--- relative to top-level spiel directory 
-examplesPath = "examples/" 
-tutorialsPath = examplesPath ++ "tutorials/"  
 
--- | Check whether all 
+-- relative to top-level spiel directory
+examplesPath = "examples/"
+tutorialsPath = examplesPath ++ "tutorials/"
+
+-- | Check whether all
 checkParseAllExamples :: IO Bool
 checkParseAllExamples = do
     exampleFiles  <- listDirectory examplesPath
-    tutorialFiles <- listDirectory tutorialsPath 
+    tutorialFiles <- listDirectory tutorialsPath
     let fullPaths = (map ((++) examplesPath) exampleFiles) ++ (map ((++) tutorialsPath) tutorialFiles)
-    let bglFiles  = filter (isExtensionOf ".bgl") (fullPaths)   
+    let bglFiles  = filter (isExtensionOf ".bgl") (fullPaths)
     putStrLn $ "\n***Parsing***\n"
     mapM putStrLn bglFiles
-    results <- mapM parseGameFile bglFiles 
-    let failures = lefts results 
+    results <- mapM parseGameFile bglFiles
+    let failures = lefts results
     putStrLn $ "\n***Failures:***"
     mapM (putStrLn . (++) "\n" . show) failures
-    return $ null failures 
-    
-testNoRepeatedParamNames :: Test 
-testNoRepeatedParamNames = TestCase $  
-   assertEqual "Test parse error on repeated params" 
-   True 
+    return $ null failures
+
+testNoRepeatedParamNames :: Test
+testNoRepeatedParamNames = TestCase $
+   assertEqual "Test parse error on repeated params"
+   True
    (isLeft $ parseLine' equation ("foo(a,a) = a + a"))
-   
+
 testNoRepeatedMetaVars :: Test
-testNoRepeatedMetaVars = TestCase $  
-   assertEqual "Test fail on repeated metavariables" 
-   True 
-   (isLeft $ parseLine' (boardeqn "myBoard") ("myBoard!(x,x) = Empty"))   
+testNoRepeatedMetaVars = TestCase $
+   assertEqual "Test fail on repeated metavariables"
+   True
+   (isLeft $ parseLine' (boardeqn "myBoard") ("myBoard!(x,x) = Empty"))
+
+-- | Double board decl
+ex2 :: String
+ex2 = "b : Board\nb!(x,y)=0\nb!(1,1)=1\nb2 : Board\nb2!(x,y)=0"
+
+-- |Tests one board declaration after another with a similar name
+testDoubleBoardDeclarations :: Test
+testDoubleBoardDeclarations = TestCase (
+  assertEqual "Test valid double board declarations"
+  True
+  (isRight $ parseAll (many decl) "" ex2)
+  )
+
+-- | Single bad board decl
+ex3 :: String
+ex3 = "b : Board\nb!(x,y)=0\nb2!(1,1)=1\nb!(0,0)=1"
+
+-- |Tests a bad board declaration, with an incorrect name in the middle
+testInvalidBoardDeclaration :: Test
+testInvalidBoardDeclaration = TestCase (
+  assertEqual "Test valid double board declarations"
+  False
+  (isRight $ parseAll (many decl) "" ex3)
+  )


### PR DESCRIPTION
Fixes #76 by adding a little `try` around an attempt to get the name of a declaration part. This allows parsec to soft fail and not consume the characters that caused the error, and another rule can match it instead (or fail).

Test cases have been added for a single board, double board decls (as shown in the issue example) and a bad case is added as well. All tests look good 👍 .