### PR TITLE
Allow Redefining Builtins

### DIFF
--- a/src/Parser/Parser.hs
+++ b/src/Parser/Parser.hs
@@ -34,8 +34,13 @@ data ParState = PS {
   ids :: [Name],
   syn :: [(Name, Xtype)]
                    }
--- | A parse context with builtins
-startState = PS Nothing ("", []) (map fst builtins ++ map fst builtinRefs) []
+-- | A parse context without builtins (before added (map fst builtins ++ map fst builtinRefs) as 2nd arg)
+-- By not passing in the names of the builtins to the parser state, we allow redefining any of the builtin definitions.
+-- Removing hiding/showing builtin definitions is a bit trickier, as they are tightly coupled in with 'builtinT' in Builtins.hs.
+-- This in turn is accessed throughout the typechecker, loading it into the environment, and using it in the Monad.hs file as well.
+-- A fix for this may take some hard rewiring of the typechecker, or a clever solution, but for now leaving it alone.
+-- @montymxb
+startState = PS Nothing ("", []) [] []
 
 type Parser = Parsec String (ParState)
 


### PR DESCRIPTION
First off, I think we should consider this optional. Although Erwig wants it in place, this fix is just kind of glossing over the real issue of hiding/showing builtins selectively. I'll open up an issue elaborating what I found for doing this for builtins, and this PR will be separate for now.

This just changes one line of code, which is a list of `Name`, this is all that constitutes what is or isn't already defined and available in terms of functions. By making this an empty list, the user can freely redefine any functions in the builtin list, as they are unchecked during parsing. If not redefined absolutely nothing changes, as the `startState` is just a superficial construct that doesn't factor into what happens later.

With this it's possible to actively hide builtins by simply redefining them to be `nop` or something that is effectively non-functional. This isn't exactly what I was looking for (or what Martin has in mind maybe), but that could work to selectively remove builtins?

Martin asked to be able to redefine builtins on Monday, so this in response to that, but I want to see what you all think first here. Perhaps there are some (like input) that we don't necessarily want the user to ever be able to change. Anyways, let me know.