### PR TITLE
Changes file descriptor of 'gamefile' to 'code'

### DIFF
--- a/src/Parser/Parser.hs
+++ b/src/Parser/Parser.hs
@@ -391,7 +391,7 @@ parsePreludeFromText content = parseFromText prelude "Prelude" content
 -- This list of possible valdefs can be obtained by parsing a prelude first, and unpacking the maybe result
 -- Such as in the case of the function above 'parsePreludeFromtext'
 parseGameFromText :: String -> [Maybe (ValDef SourcePos)] -> Either ParseError (Game SourcePos)
-parseGameFromText content possibleValdefs = parseFromText (parseGame (catMaybes possibleValdefs)) "Gamefile" content
+parseGameFromText content possibleValdefs = parseFromText (parseGame (catMaybes possibleValdefs)) "Code" content
 
 -- | Parse a prelude and game from text directly, without a file
 parsePreludeAndGameText :: String -> String -> IO (Either ParseError (Game SourcePos))


### PR DESCRIPTION
Relatively small PR. Changes 'Gamefile' to 'Code' internally to match with the tab on the frontend. In this way, if parse errors occur they will indicate that they happened in 'Code' now. Closes #96.