### PR TITLE
Fixes bind issues and errors for builtins param type mismatch

### DIFF
--- a/examples/ConnectFour.bgl
+++ b/examples/ConnectFour.bgl
@@ -63,6 +63,3 @@ loop(p,b) = while not(gameOver(b)) do tryMove(p,b)
 
 play : (Player, Board) -> Player & {Tie}
 play(a,b) = outcome(loop(a,b))
-
-result : Player & {Tie}
-result = play(initialBoard,goFirst)

--- a/src/Runtime/Eval.hs
+++ b/src/Runtime/Eval.hs
@@ -28,7 +28,7 @@ bindings sz vs = e
                                 Right v' -> return $ modifyEval ((n, v'):) env
                                 Left err -> (tell [err]) >> return env)
         (emptyEnv sz)
-        (reverse $ map bind vs)
+        (map bind vs)
 
 
 bindings_ :: (Int, Int) -> [ValDef a] -> Env


### PR DESCRIPTION
This closes #87. It introduces a couple of changes.
- Swaps the bind order of value definitions at runtime, which allows variable equations to properly observe the environment.
- Allows Builtins to report errors if the parameter to their lambdas are not quite right (this in part affected the same issue #87)

This is NOT done. Still needs a patch to Connect4 (which has a typo in it towards the end), and needs to be tested across all examples individually to ensure no subtle bugs are introduced.