### PR TITLE
Closes #106, allows type synonyms to propagate from prelude to gamefile

### DIFF
--- a/src/Language/Syntax.hs
+++ b/src/Language/Syntax.hs
@@ -43,21 +43,26 @@ instance Show Parlist where
   show (Pars xs) = "(" ++ intercalate (" , ") (xs) ++ ")"
 
 -- | Top level values are signatures paired with either an ordinary 'Equation'
-data ValDef a = Val Signature (Equation a) a
+data ValDef a =
+    Val Signature (Equation a) a
   | BVal Signature [BoardEq a] a
+  | TSynVal Signature -- TypeSynonymValue, used for collecting type synonyms in the parser, no equation
    deriving (Eq, Generic)
 
 instance Functor ValDef where
   fmap f (Val s e a) = Val s (fmap f e) (f a)
   fmap f (BVal s e a) = BVal s ((fmap . fmap) f e) (f a)
+  fmap f (TSynVal s) = TSynVal s
 
 instance Show (ValDef a) where
   show (Val s e _) = show s ++ "\n" ++ show e
   show (BVal s e _) = show s ++ "\n" ++ show e
+  show (TSynVal s) = show s
 
 ident :: (ValDef a) -> Name
 ident (Val (Sig n _) _ _) = n
 ident (BVal (Sig n _) _ _) = n
+ident (TSynVal (Sig n _)) = n
 
 -- | Equations:
 data Equation a = Veq Name (Expr a)        -- ^ Value equations (a mapping from 'Name' to 'Expr')

--- a/src/Runtime/Eval.hs
+++ b/src/Runtime/Eval.hs
@@ -51,6 +51,14 @@ bind (BVal (Sig n _) defs _) = (n, do
       newBoard sz = array ((1,1), sz) (zip [(x,y) | x <- [1..(fst sz)], y <- [1..(snd sz)]] (repeat (Vs "?"))) -- TODO: replace ?
       fill board sz ds vs = foldl (\b p -> updateBoard b sz (fst p) (snd p)) board (zip ds vs)
 
+-- Type Syn val hack, allows types to propagate from
+-- prelude to gamefile w/out being seriously considered
+-- TODO This might be an ideal location to type check the Values this type synonym references?
+bind (TSynVal (Sig n _)) = (n, do
+  env <- getEnv
+  eval (I 1))
+
+
 updateBoard :: Board -> (Int, Int) -> (BoardEq a) -> Val -> Board
 updateBoard b sz d v = let indices = range ((1,1), sz) in
                               b // zip (filter (posMatches (xpos d) (ypos d)) indices) (repeat v)

--- a/src/Typechecker/Typechecker.hs
+++ b/src/Typechecker/Typechecker.hs
@@ -42,6 +42,9 @@ deftype (BVal (Sig n t) eqs x) = do
     Nothing -> return t
     (Just badEqn) -> sigmismatch n t badEqn
 
+deftype (TSynVal (Sig n t)) = do
+  return t -- just return the type synonym as it is
+
 -- | Get the type of a board equation.
 beqntype :: Type -> (BoardEq SourcePos) -> Typechecked Type
 beqntype t (PosDef _ xp yp e) = do
@@ -147,6 +150,7 @@ environment :: BoardDef -> InputDef -> [ValDef SourcePos] -> Env
 environment (BoardDef sz t) (InputDef i) vs = Env (map f vs ++ (builtinT i t)) i t sz
   where f (Val (Sig n t1) eq x) = (n, t1)
         f (BVal (Sig n t1) eq x) = (n, t1)
+        f (TSynVal (Sig n t1)) = (n, t1)
 
 -- recursion is not allowed by this.
 runTypeCheck :: BoardDef -> InputDef -> [ValDef SourcePos] -> Writer [Either (ValDef SourcePos, TypeError) (Name, Type)] Env

--- a/test/ParserTests.hs
+++ b/test/ParserTests.hs
@@ -25,7 +25,8 @@ parserTests = TestList [
   parseBoardTests,
   parseGameNameTests,
   testDivByZeroBad,
-  testUnderscoresInTypes
+  testUnderscoresInTypes,
+  testProperTypeSharing
   ]
 
 --
@@ -164,7 +165,7 @@ examplesPath = "examples/"
 tutorialsPath :: String
 tutorialsPath = examplesPath ++ "tutorials/"
 
--- | Check whether all
+-- | Check whether all examples are capable of being parsed
 checkParseAllExamples :: IO Bool
 checkParseAllExamples = do
     exampleFiles  <- listDirectory examplesPath
@@ -363,3 +364,30 @@ testUnderscoresInTypes = TestCase (
   assertEqual "Tests that types allow underscores in them"
   True
   (isRight $ parseAll (parseGame []) "" "game E\ntype Board=Array(1,1) of Int\ntype Input=Int\ntype Under_Type={U_1,U_2,U3_24A}"))
+
+
+-- | Simple game header to use in tests
+sg :: String
+sg = "game G\ntype Board=Array(1,1) of Int\ntype Input=Int\n"
+
+
+-- | Tests that types declared in the code are available in the prelude, and vice versa
+-- at the appropriate points
+testProperTypeSharing :: Test
+testProperTypeSharing = TestCase (
+  assertEqual "Tests that types are properly shared amongst a prelude & gamefile"
+  True
+  (case parsePreludeFromText "type Prelude_Type={A,B}" of
+    Right valdefs -> isRight $ parseGameFromText (sg ++ "f:Prelude_Type\nf=A") valdefs
+    Left err      -> False))
+
+{--
+testParseRawPreludeAndGamefile :: Test
+testParseRawPreludeAndGamefile = TestCase $
+  assertEqual "Test unable to parse raw prelude and gamefile text"
+  True
+  (case parsePreludeFromText rawPrelude of
+    Right valdefs -> isRight $ parseGameFromText rawGamecode valdefs
+    Left err      -> False
+  )
+--}


### PR DESCRIPTION
This introduces a new Value Definition `TSynVal` to allow for the propagation of Type Synonyms from the prelude to the main gamefile/code. Before type synonyms were recognized only within the context of a given parsec run, and so were lost once parsing of the prelude was done. This allowed for some strange behavior, as documented in #106, where types could not only be redundantly declared in both files, but that there would also be no parse errors for re-declaring a previously used unique name.