### PR TITLE
Hotfixes, Adds /=, Fixes lowercase typename issue, Removes 'next'

### DIFF
--- a/examples/Adventure.bgl
+++ b/examples/Adventure.bgl
@@ -1,0 +1,63 @@
+--
+-- A basic adventure game,
+-- where a player can be moved on a 5x5
+-- board by entering WASD
+--
+game AdventureGame
+
+-- Directions the player can enter
+-- E allows exiting the game
+type Direction = {W,A,S,D,E}
+
+-- X is a wall, O is a path, P is a player
+type Entity = {X,O,P}
+
+type Board = Array(5,5) of Entity
+type Input = Direction
+
+-- size of the board
+size : Int
+size = 5
+
+-- initial board of all O's
+board : Board
+board!(x,y) = O
+
+--
+-- To play the game run as follows in the interpreter:
+-- play(1,1)
+--
+play : (Int,Int) -> Board
+play(x,y) = let dir = input in
+            if dir == S then
+					if y+1 > size then
+						play(x,y)
+					else
+						let bb = place(P,board,(x,y+1)) in
+						play(x,y+1)
+				else
+					if dir == W then
+						if y-1 < 1 then
+							play(x,y)
+						else
+							let bb = place(P,board,(x,y-1)) in
+							play(x,y-1)
+					else
+						if dir == A then
+							if x-1 < 1 then
+								play(x,y)
+							else
+								let bb = place(P,board,(x-1,y)) in
+								play(x-1,y)
+						else
+							if dir == D then
+								if x+1 > size then
+									play(x,y)
+								else
+									let bb = place(P,board,(x+1,y)) in
+									play(x+1,y)
+							else
+								if dir == E then
+									board
+								else
+									play(x,y)

--- a/src/Language/Syntax.hs
+++ b/src/Language/Syntax.hs
@@ -162,6 +162,7 @@ data Op = Plus
         | Less
         | Leq
         | Equiv
+        | NotEquiv
         | Geq
         | Greater
         | Get           -- Gets contents from a position on a board
@@ -176,6 +177,7 @@ instance Show Op where
   show Less     = " < "
   show Leq      = " <= "
   show Equiv    = " == "
+  show NotEquiv = " /= "
   show Geq      = " >= "
   show Greater  = " > "
   show Get      = " ! "

--- a/src/Runtime/Builtins.hs
+++ b/src/Runtime/Builtins.hs
@@ -28,7 +28,7 @@ builtinT = \inputT pieceT -> [
   ("countDiag", Function (Ft (Tup [pieceT, (X Board S.empty)]) (X Itype S.empty))),
   ("isFull", Function (Ft (single (X Board S.empty)) (X Booltype S.empty))),
   ("inARow", Function (Ft (Tup [X Itype S.empty, pieceT, X Board S.empty]) (X Booltype S.empty))),
-  ("next", Function (Ft (single (X Top (S.fromList ["X", "O"]))) (X Top (S.fromList ["X", "O"])))),
+  --("next", Function (Ft (single (X Top (S.fromList ["X", "O"]))) (X Top (S.fromList ["X", "O"])))),
   ("not", Function (Ft (single (X Booltype S.empty)) (X Booltype S.empty))),
   ("or", Function (Ft (Tup [X Booltype S.empty, X Booltype S.empty]) (X Booltype S.empty))),
   ("and", Function (Ft (Tup [X Booltype S.empty, X Booltype S.empty]) (X Booltype S.empty)))
@@ -56,7 +56,7 @@ builtinsChecker "countRow" [v, Vboard arr] = return $ Vi $ countRow arr v
 builtinsChecker "countDiag" [v, Vboard arr] = return $ Vi $ countDiag arr v
 builtinsChecker "isFull" [Vboard arr] = return $ Vb $ all (/= Vs "Empty") $ elems arr
 builtinsChecker "inARow" [Vi i, v, Vboard arr] = return $ Vb $ inARow arr v i
-builtinsChecker "next" [Vs s] = return $ if s == "X" then Vs "O" else Vs "X"
+--builtinsChecker "next" [Vs s] = return $ if s == "X" then Vs "O" else Vs "X"
 builtinsChecker "not" [Vb b] = return $ Vb (not b)
 builtinsChecker "or" [Vb a, Vb b] = return $ Vb (a || b)
 builtinsChecker "and" [Vb a, Vb b] = return $ Vb (a && b)
@@ -73,7 +73,7 @@ builtins = [
   ("countDiag", \x -> builtinsChecker "countDiag" x),
   ("isFull", \x -> builtinsChecker "isFull" x),
   ("inARow", \x -> builtinsChecker "inARow" x),
-  ("next", \x -> builtinsChecker "next" x),
+  --("next", \x -> builtinsChecker "next" x),
   ("not", \x -> builtinsChecker "not" x),
   ("or", \x -> builtinsChecker "or" x),
   ("and", \x -> builtinsChecker "and" x)

--- a/src/Typechecker/Typechecker.hs
+++ b/src/Typechecker/Typechecker.hs
@@ -106,6 +106,11 @@ exprtype e@(Binop Equiv e1 e2) = do
   t2 <- exprtype e2
   unify t1 t2
   t Booltype
+exprtype e@(Binop NotEquiv e1 e2) = do
+  t1 <- exprtype e1
+  t2 <- exprtype e2
+  unify t1 t2
+  t Booltype
 exprtype (Binop Get e1 e2) = do
   t1 <- exprtype e1
   t2 <- exprtype e2

--- a/test/EvalTests.hs
+++ b/test/EvalTests.hs
@@ -15,17 +15,54 @@ import Runtime.Values
 evalTests :: Test
 evalTests = TestList [
   testEvalEquiv,
+  testEvalNotEquiv,
+  testWrongArgsInNotEquiv,
+  testEvalNotEquivSymbols,
+  testEvalEquivSymbols,
+  testEvalLeqNotForSymbols,
   testEvalPlusMinusTimes,
   testBadTypesPlus,
   testEval2,
   testEvalTuple,
-  testEvalLetRef]
+  testEvalLetRef,
+  testEvalNextNotPresent]
 
 testEvalEquiv :: Test
 testEvalEquiv = TestCase (
   assertEqual "Test equiv in eval"
   (Right (Vb False))
   (evalTest (eval (Binop Equiv (I 3) (I 4)))))
+
+-- | Verifies that /= works for operands that are not equivalent
+testEvalNotEquiv :: Test
+testEvalNotEquiv = TestCase (
+  assertEqual "Test not equiv in eval"
+  (Right (Vb True))
+  (evalTest (eval (Binop NotEquiv (I 92) (I 64)))))
+
+testWrongArgsInNotEquiv :: Test
+testWrongArgsInNotEquiv = TestCase (
+  assertEqual "Test bad args in not equiv via eval"
+  True
+  (isRightErr (evalTest (eval (Binop NotEquiv (I 92) (S "Oops"))))))
+
+testEvalNotEquivSymbols :: Test
+testEvalNotEquivSymbols = TestCase (
+  assertEqual "Tests that /= works for symbols"
+  (Right (Vb True))
+  (evalTest (eval (Binop NotEquiv (S "A") (S "B")))))
+
+testEvalEquivSymbols :: Test
+testEvalEquivSymbols = TestCase (
+  assertEqual "Tests that == works for symbols"
+  (Right (Vb False))
+  (evalTest (eval (Binop Equiv (S "A") (S "B")))))
+
+testEvalLeqNotForSymbols :: Test
+testEvalLeqNotForSymbols = TestCase (
+  assertEqual "Tests that <= does not work for symbols"
+  True
+  (isRightErr (evalTest (eval (Binop Leq (S "A") (S "B"))))))
 
 testEvalPlusMinusTimes :: Test
 testEvalPlusMinusTimes = TestCase (
@@ -65,3 +102,9 @@ testEvalLetRef = TestCase (
   assertEqual "Test eval let and ref"
   (Right (Vi 2))
   (evalTest (eval (Let "x" (I 2) (Ref "x")))))
+
+testEvalNextNotPresent :: Test
+testEvalNextNotPresent = TestCase (
+  assertEqual "Test 'next' not builtin anymore"
+  True
+  (isRightErr (evalTest (eval (App "next" (Tuple [(S "X")]))))))

--- a/test/ParserTests.hs
+++ b/test/ParserTests.hs
@@ -27,7 +27,8 @@ parserTests = TestList [
   testDivByZeroBad,
   testUnderscoresInTypes,
   testProperTypeSharing,
-  testOptionalBoardInputTests
+  testOptionalBoardInputTests,
+  testTypeSynCannotBeItsOwnValue
   ]
 
 --
@@ -79,7 +80,9 @@ parseDeclTests = TestLabel "Parse Declaration Tests" (TestList [
   testParseTypeSynAndDecl,
   testNoRepeatedParamNames,
   testNoRepeatedMetaVars,
-  testAnySymbolDisallowed
+  testAnySymbolDisallowed,
+  testLowerCaseTypeNamesDisallowed_inDecl,
+  testLowerCaseTypeNamesDisallowed_inGame
   ])
 
 
@@ -151,6 +154,22 @@ testAnySymbolDisallowed = TestCase (
   False
   (isRight $ parseAll (many decl) "" "f:AnySymbol\nf=X")
   )
+
+
+-- | Tests that lowercase letters cannot start a type syn name (in decl)
+testLowerCaseTypeNamesDisallowed_inDecl :: Test
+testLowerCaseTypeNamesDisallowed_inDecl = TestCase (
+  assertEqual "Tests that type syns can't begin with a lowercase character"
+  False
+  (isRight $ parseAll (many decl) "" "type oops={A,B}"))
+
+
+-- | Tests that lowercase letters cannot start a type syn name (in typesyn)
+testLowerCaseTypeNamesDisallowed_inGame :: Test
+testLowerCaseTypeNamesDisallowed_inGame = TestCase (
+  assertEqual "Tests that type syns can't begin with a lowercase character"
+  False
+  (isRight $ parseAll (parseGame []) "" "game E\ntype oops={A,B}"))
 
 
 --
@@ -467,3 +486,11 @@ testSimilarTypeToInputOkay = TestCase (
   assertEqual "Test that type synonym 'Inputs' isn't mixed up with 'Input'"
   True
   (isRight $ parseAll (parseGame []) "" "game E\ntype Inputs=Int"))
+
+-- | Tests that 'type AB = {AB}' is not a valid type syn
+-- A type syn cannot be a value of itself
+testTypeSynCannotBeItsOwnValue :: Test
+testTypeSynCannotBeItsOwnValue = TestCase (
+  assertEqual "Test that a type syn cannot be listed as one of it's own symbols"
+  False
+  (isRight $ parseAll (parseGame []) "" "game E\ntype AB={AB}"))

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -1,4 +1,4 @@
-module Utils(evalTest) where
+module Utils(evalTest,isRightErr) where
 --
 -- Utils.hs
 --
@@ -12,3 +12,8 @@ import Runtime.Monad
 -- used to extract value from expression
 evalTest :: Eval Val -> Either Exception Val
 evalTest ev = runEval (emptyEnv (0,0)) ([], []) ev
+
+isRightErr :: Either Exception Val -> Bool
+isRightErr m = case m of
+                Right (Err _) -> True
+                _             -> False


### PR DESCRIPTION
Various fixes after the 7/24 meeting, some noted in advance, and some caught while actively working:
- add '/=' expression, and verifies it fails for non-matching types
- fixes '==' to not succeed for non-matching types
- prevents a type syn from being a value of itself or of another type syn in it's enum, i.e. `type A = {A}`
- fixes regression of #104, where type names should not be lower case, adds test against this now
- removes 'next' as a builtin
- adds 'Adventure' to list of example programs, akin to a bare-bones simple command line game.