### PR TITLE
Report Runtime Error on Invalid Board Index

### DIFF
--- a/test/EvalTests.hs
+++ b/test/EvalTests.hs
@@ -11,6 +11,7 @@ import Runtime.Eval
 import Language.Syntax
 import Runtime.Monad
 import Runtime.Values
+import Data.Array
 
 evalTests :: Test
 evalTests = TestList [
@@ -25,7 +26,8 @@ evalTests = TestList [
   testEval2,
   testEvalTuple,
   testEvalLetRef,
-  testEvalNextNotPresent]
+  testEvalNextNotPresent,
+  testNegativeBoardAccess]
 
 testEvalEquiv :: Test
 testEvalEquiv = TestCase (
@@ -108,3 +110,15 @@ testEvalNextNotPresent = TestCase (
   assertEqual "Test 'next' not builtin anymore"
   True
   (isRightErr (evalTest (eval (App "next" (Tuple [(S "X")]))))))
+
+-- | Tests that negative board access doesn't crash out things
+testNegativeBoardAccess :: Test
+testNegativeBoardAccess = TestCase (
+  assertEqual "Test that evaluating a negative board position gives an appropriate error"
+  True
+  (isRightErr (let barray = array ((1,1),(1,1)) [((1,1),(Vi 1))] in
+   let board  = Vboard barray in
+   let env    = Env [("b", board)] (1,1) in
+   let buffer = ([],[]) in
+   let evalVal= eval (Ref "b!(1,-1)") in
+   runEval env buffer evalVal)))


### PR DESCRIPTION
Closes #119 by sanity checking the x and y components of the board index for accessing an element. If the index is out of bounds, an error with a helpful message is reported instead of a crash.