### PR TITLE
Forces Lowercase Identifiers

### DIFF
--- a/src/Parser/Parser.hs
+++ b/src/Parser/Parser.hs
@@ -316,7 +316,7 @@ typ =
 -- | Value signatures
 sig :: Parser Signature
 sig =
-  Sig <$> new identifier <*> (reservedOp ":" *> typ)
+  lookAhead lower *> (Sig <$> new identifier <*> (reservedOp ":" *> typ))
 
 -- | Value definitions
 valdef :: Parser (ValDef SourcePos)

--- a/test/ParserTests.hs
+++ b/test/ParserTests.hs
@@ -496,7 +496,7 @@ testTypeSynCannotBeItsOwnValue = TestCase (
   False
   (isRight $ parseAll (parseGame []) "" "game E\ntype AB={AB}"))
 
--- | Tests taht identifiers must starst with a lowercase alpha char
+-- | Tests that identifiers must starst with a lowercase alpha char
 testIdentifiersMustBeLower :: Test
 testIdentifiersMustBeLower = TestCase (
   assertEqual "Tests that identifiers must begin with a lowercase character"

--- a/test/ParserTests.hs
+++ b/test/ParserTests.hs
@@ -28,7 +28,8 @@ parserTests = TestList [
   testUnderscoresInTypes,
   testProperTypeSharing,
   testOptionalBoardInputTests,
-  testTypeSynCannotBeItsOwnValue
+  testTypeSynCannotBeItsOwnValue,
+  testIdentifiersMustBeLower
   ]
 
 --
@@ -494,3 +495,10 @@ testTypeSynCannotBeItsOwnValue = TestCase (
   assertEqual "Test that a type syn cannot be listed as one of it's own symbols"
   False
   (isRight $ parseAll (parseGame []) "" "game E\ntype AB={AB}"))
+
+-- | Tests taht identifiers must starst with a lowercase alpha char
+testIdentifiersMustBeLower :: Test
+testIdentifiersMustBeLower = TestCase (
+  assertEqual "Tests that identifiers must begin with a lowercase character"
+  False
+  (isRight $ parseAll (many decl) "" "F:Int\nF=5\nF2:Int->Int\nF2(x)=x"))


### PR DESCRIPTION
Closes #121 by forcing a lookahead operation in the parsing of identifiers for an initial lowercase character. It seems that before this wasn't an issue, but something has subtly been changed in the parser during a prior patch, and so things need to be watched over carefully. Existing tests look good, and this adds a case that was originally failing beforehand.