### PR TITLE
Better Param Typechecking

### DIFF
--- a/src/Runtime/Eval.hs
+++ b/src/Runtime/Eval.hs
@@ -183,22 +183,25 @@ eval (Let n e1 e2) = do
 
 eval (If p e1 e2) = do
   b <- unpackBool <$> (eval p)
-  if b then eval e1 else eval e2
+  case b of
+    (Just bb) -> if bb then eval e1 else eval e2
+    Nothing   -> return $ Err $ "The expression " ++ show p ++ " did not evaluate to a Bool as expected!"
 
 eval (Binop op e1 e2) = evalBinOp op e1 e2
 
 eval (While c b names exprs) = do
    c' <- unpackBool <$> eval c   -- evaluate the condition
    case c' of
-      True  -> do
+      (Just True)  -> do
          env <- getEnv                          -- get the current environment
          result <- eval b                                       -- evaluate the body
          case result of                                         -- update the variables in the environment w/ new values and recurse:
             (Vt vs) -> extScope ((zip names vs) ++ env) recurse
             r       -> extScope ((head names, r) : env) recurse -- that head should never fail...famous last words
-      False -> do
+      (Just False) -> do
         e <- eval exprs
         return e
+      Nothing      -> return $ Err $ "The expression " ++ show c ++ " did not evaluate to a Bool as expected!"
    where
       recurse = eval (While c b names exprs)
 

--- a/src/Runtime/Monad.hs
+++ b/src/Runtime/Monad.hs
@@ -80,9 +80,9 @@ readTape = do
     [] -> waitForInput boards
 
 -- | Helper function to get the Bool out of a value. This is a partial function.
-unpackBool :: Val -> Bool
-unpackBool (Vb b) = b
-unpackBool _ = undefined
+unpackBool :: Val -> Maybe Bool
+unpackBool (Vb b) = Just b
+unpackBool v = Nothing      -- not a valid boolean, should trip a runtime error
 
 
 -- | Bind the value of a definition to its name in the current Environment

--- a/src/Typechecker/Typechecker.hs
+++ b/src/Typechecker/Typechecker.hs
@@ -105,7 +105,7 @@ exprtype e@(App n es) = do -- FIXME. Tuple composition is bad.
           u <- unify (es'') i -- oof
           case u of
             -- verify the unified result is ultimately the same as the input type
-            x1 -> if x1 == i then return o else mismatch (Plain es'') (Function (Ft i o))
+            x1 -> if x1 == i then return o else mismatch (Plain es'') (Plain i)
     _ -> do
       (traceM "???") >> mismatch (Function $ (Ft es' (X Undef S.empty))) t -- TODO Get expected output from enviroment (fill in Undef what we know it should be)
 exprtype e@(Binop Equiv e1 e2) = do

--- a/src/Typechecker/Typechecker.hs
+++ b/src/Typechecker/Typechecker.hs
@@ -96,9 +96,16 @@ exprtype e@(App n es) = do -- FIXME. Tuple composition is bad.
         x -> x
   t <- getType n
   case t of
-    (Function (Ft (i) o)) -> do
-      unify (es'') i -- oof
-      return o
+    (Function (Ft i o)) -> do
+      if es'' == i then
+        return o -- supplied param matches expected input type
+      else
+        do
+          -- otherwise, unify the supplied param w/ the input type
+          u <- unify (es'') i -- oof
+          case u of
+            -- verify the unified result is ultimately the same as the input type
+            x1 -> if x1 == i then return o else mismatch (Plain es'') (Function (Ft i o))
     _ -> do
       (traceM "???") >> mismatch (Function $ (Ft es' (X Undef S.empty))) t -- TODO Get expected output from enviroment (fill in Undef what we know it should be)
 exprtype e@(Binop Equiv e1 e2) = do

--- a/test/ParserTests.hs
+++ b/test/ParserTests.hs
@@ -1,4 +1,4 @@
-module ParserTests(parserTests, checkParseAllExamples) where
+module ParserTests(parserTests, checkParseAllExamples, ParserTestResult(), parsePassed) where
 
 --
 -- Parser Tests
@@ -174,9 +174,26 @@ testLowerCaseTypeNamesDisallowed_inGame = TestCase (
 --
 --
 
+-- | Represents the rest result for typchecking examples
+-- On Fail, return # failures for easier analysis in the cmd line
+data ParserTestResult =
+  Fail Int |
+  Pass
 
--- | Check whether all
-checkParseAllExamples :: IO Bool
+-- | Allows displaying of a parser example checking result
+instance Show ParserTestResult where
+  show (Fail fails) = "Parsing all Examples\n Failures: " ++ show fails
+  show Pass         = "Parsing all Examples\n Failures: 0\n (Passed)"
+
+
+-- | Determines whether a type checker result is passing or not
+parsePassed :: ParserTestResult -> Bool
+parsePassed (Fail _ ) = False
+parsePassed Pass      = True
+
+
+-- | Check whether all examples pass parsing
+checkParseAllExamples :: IO ParserTestResult
 checkParseAllExamples = do
     bglFiles <- getExampleFiles
     logTestStmt "Parsing:"
@@ -185,7 +202,8 @@ checkParseAllExamples = do
     let allfailures = lefts results
     logTestStmt "Failures:"
     mapM_ (putStrLn . (++) "\n" . show) allfailures
-    return $ null allfailures
+    let failCount = length allfailures
+    return $ if failCount < 1 then Pass else (Fail failCount)
 
 
 -- | Raw prelude code for the test below

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -9,14 +9,12 @@ import TypeCheckerTests
 spielTests :: Test
 spielTests = TestList [parserTests,evalTests]
 
---data Counts = Counts { cases, tried, errors, failures :: Int }
--- deriving (Eq, Show, Read)
-
 -- run all tests in the suite
 main :: IO ()
 main =  do
-  result <- runTestTT spielTests
-  parseSuccess <- checkParseAllExamples
-  tcSuccess    <- typeCheckAllExamples
-  let failed = or [(errors result) > 0, (failures result) > 0, not parseSuccess, not tcSuccess]
+  result     <- runTestTT spielTests  -- Run standard HUnit tests
+  parseResult<- checkParseAllExamples -- Custom test: parse all examples, return Pass | (Fail #failures)
+  tcResult   <- typeCheckAllExamples  -- Custom test: tc all examples, return Pass | (Fail #failures #errors)
+  let failed = or [(errors result) > 0, (failures result) > 0, not $ parsePassed parseResult, not $ tcPassed tcResult]
+  putStrLn ("\n\n" ++ show tcResult ++ "\n\n" ++ show parseResult ++ "\n") -- print example TC/Parse results for verification
   if failed then exitFailure else exitSuccess

--- a/test/TypeCheckerTests.hs
+++ b/test/TypeCheckerTests.hs
@@ -22,6 +22,23 @@ import Typechecker.Monad
 typeCheckerTests :: Test
 typeCheckerTests = TestList []
 
+-- | Represents the rest result for typchecking examples
+-- On Fail, return # failures & # errors for easier analysis in the cmd line
+data TypeCheckerTestResult =
+  Fail Int Int |
+  Pass
+
+-- | Allows displaying of a typechecker example checking result
+instance Show TypeCheckerTestResult where
+  show (Fail fails errs) = "Typechecking all Examples\n Failures: " ++ show fails ++ " Errors: " ++ show errs
+  show Pass              = "TypeChecking all Examples\n Failures: 0 Errors: 0\n (Passed)"
+
+
+-- | Determines whether a type checker result is passing or not
+tcPassed :: TypeCheckerTestResult -> Bool
+tcPassed (Fail _ _) = False
+tcPassed Pass       = True
+
 --
 -- TEST STRUCTURE
 --
@@ -32,7 +49,7 @@ typeCheckerTests = TestList []
 --  ExpressionToCheck)
 --
 
-typeCheckAllExamples :: IO Bool
+typeCheckAllExamples :: IO TypeCheckerTestResult
 typeCheckAllExamples = do
    bglFiles <- getExampleFiles
    logTestStmt "Type checking:"
@@ -43,4 +60,6 @@ typeCheckAllExamples = do
        errs = map Typechecker.Typechecker.errors failures
    logTestStmt "Failures:"
    mapM_ (putStrLn . ("\n" ++)) (map showTCError (concat errs))
-   return $ null failures
+   let errCount = length errs
+   let failCount= length failures
+   return $ if errCount > 0 || failCount > 0 then (Fail failCount errCount) else Pass


### PR DESCRIPTION
Closes #110, and closes #102, where bad parameter types could sneak by if symbols were asked for. This is done first by checking to see if the type of the supplied parameter matches the expected input type for a function. If that fails the two are attempted to be unified, and the result is checked back against the expected input type (which should be equivalent now). If the second attempt fails then the typechecker fails with an error. As an example:
```haskell
game Ex
type AB = {A,B}
b : AB -> AB
b(x) = x
```
and in the interpreter you get the following results (one correct, 2 incorrect):
```
> b(A)

A

> b(C)

Type error at: (line 1, column 3) in the Interpreter expression
Could not match types ({C}) and ({A, B}) in expression:
	b(C)

> b(1)

Type error at: (line 1, column 3) in the Interpreter expression
Could not match types (Int) and ({A, B}) in expression:
	b(1)
```
as can be seen, this catches input symbols that are incorrect.

Some additional test changes were made to count the number of failures for parsing and typechecking, and existing test cases look sufficient to verify this works (until we introduce standalone typechecking tests).

Also fixes a small issue related to unpacking booleans from evaluated expressions. In some cases, an expected bool value would fail and produce a value of **undefined**. This would crash the run and send no response back to the user. With this change, the user will at least get feedback that an expression could not be evaluated if it's condition did not resolve to a boolean value. Ideally this shouldn't happen, as the typechecker should catch such things.

It's possible that changes to the typechecker may later alter or remove this depending on the design choices, but for now this will help catch a number of expressions that are not type correct.