### PR TITLE
Changes Mod to infix '%'

### DIFF
--- a/src/Parser/Parser.hs
+++ b/src/Parser/Parser.hs
@@ -93,8 +93,7 @@ lexer = P.makeTokenParser (haskellStyle {P.reservedNames =
 -- | Operators (might want to fix the order of operations)
 operators = [
              [op "!" (Binop Get) AssocLeft],
-             [op "*" (Binop Times) AssocLeft, op "/" (Binop Div) AssocLeft,
-               op "mod" (Binop Mod) AssocLeft],
+             [op "*" (Binop Times) AssocLeft, op "/" (Binop Div) AssocLeft, op "%" (Binop Mod) AssocLeft],
              [op "+" (Binop Plus) AssocLeft, op "-" (Binop Minus) AssocLeft],
              [op "<" (Binop Less) AssocLeft],
              [op "<=" (Binop Leq) AssocLeft],

--- a/test/EvalTests.hs
+++ b/test/EvalTests.hs
@@ -16,6 +16,7 @@ import Data.Array
 evalTests :: Test
 evalTests = TestList [
   testEvalEquiv,
+  testEvalMod,
   testEvalNotEquiv,
   testWrongArgsInNotEquiv,
   testEvalNotEquivSymbols,
@@ -35,6 +36,13 @@ testEvalEquiv = TestCase (
   assertEqual "Test equiv in eval"
   (Right (Vb False))
   (evalTest (eval (Binop Equiv (I 3) (I 4)))))
+
+-- | Tests the mod can be correctly evaluated
+testEvalMod :: Test
+testEvalMod = TestCase (
+  assertEqual "Test mod in eval"
+  (Right (Vi 0))
+  (evalTest (eval (Binop Mod (I 8) (I 2)))))
 
 -- | Verifies that /= works for operands that are not equivalent
 testEvalNotEquiv :: Test

--- a/test/ParserTests.hs
+++ b/test/ParserTests.hs
@@ -8,7 +8,6 @@ import Test.HUnit
 import Parser.Parser
 import Language.Types
 import qualified Data.Set as S
-import Text.Parsec.Error
 import Data.Either
 import Text.Parsec
 import Utils
@@ -78,6 +77,7 @@ parseDeclTests :: Test
 parseDeclTests = TestLabel "Parse Declaration Tests" (TestList [
   testRejectBadExprAfterSuccessefulParse,
   testParseShortDecl,
+  testParseMod,
   testParseTypeSynAndDecl,
   testNoRepeatedParamNames,
   testNoRepeatedMetaVars,
@@ -108,6 +108,13 @@ testParseShortDecl = TestCase (
   True
   (isRight $ parseAll valdef "" "hello : Int\nhello = 24")
   )
+
+-- | Tests that infix mod '%' can be parsed correctly
+testParseMod :: Test
+testParseMod = TestCase (
+  assertEqual "Test that the parser recognizes '%' as infix mod"
+  True
+  (isRight $ (parseAll valdef "" "test:Int\ntest = 5 % 2")))
 
 
 -- |Tests parsing a type declaration followed by variable declaration


### PR DESCRIPTION
This is a quick mid-camp patch to introduce mod as an infix `%`. Before it was present, but as an infix `mod`. This wasn't incorrect in any way, but it was misleading, as it's the only one of the common binary mathematical operators that was not an infix symbol.