### PR TITLE
Add Expr for Board Equation into State before TC

### DIFF
--- a/src/Typechecker/Monad.hs
+++ b/src/Typechecker/Monad.hs
@@ -119,8 +119,7 @@ getSrc :: Typechecked (Expr SourcePos)
 getSrc = do
   e <- source <$> get
   case e of
-    Nothing -> unknown "!" -- TODO FIXME: This seems to popup when you assign an invalid type on a board (I think),
-                           -- either that or an invalid index, one of the 2 (can be checked) @montymxb
+    Nothing -> unknown "Unable to get source expression!"
     Just _e -> return _e
 
 -- | Get a type from the environment

--- a/src/Typechecker/Typechecker.hs
+++ b/src/Typechecker/Typechecker.hs
@@ -62,7 +62,7 @@ deftype (BVal (Sig n _t) eqs x) = do
 -- | Get the type of a board equation
 beqntype :: BoardEq SourcePos -> Typechecked Type
 beqntype (PosDef _ xp yp _e) = do
-   et <- exprtype _e
+   et <- exprtypeE _e
    pt <- getPiece
    (mx, my) <- getSize
    case (et <= pt, xp <= Index mx && xp > Index 0, yp <= Index my && yp > Index 0) of

--- a/test/TypeCheckerTests.hs
+++ b/test/TypeCheckerTests.hs
@@ -32,6 +32,7 @@ typeCheckerTests = TestList
    ,testIncompleteBoardEq
    ,testOneSpaceIncompleteBoardEq
    ,testCompleteBoardEq
+   ,testBoardTypeMismatch
    ]
 
 -- | Represents the rest result for typchecking examples
@@ -201,3 +202,14 @@ testCompleteBoardEq = TestCase (
   (assertBool "Verifies that an complete board equation is valid") $
   allPassTC [testGame [(BVal (Sig "b" (Plain boardxt)) [PosDef "b" (ForAll ("x")) (ForAll ("y")) (I 1)] dummyPos)]]
   )
+
+-- | Test TC on expression for board equation where there should be a type mismatch
+testBoardTypeMismatch :: Test
+testBoardTypeMismatch = TestCase (
+  assertBool "Verifies that a board type with an incorrect expr type reports a mismatch properly" $
+  let beqn = (BVal (Sig "b" (Plain boardxt)) [PosDef "b" (ForAll ("x")) (ForAll ("y")) (B True)] dummyPos) in
+  case tc $ testGame [beqn] of
+    -- failed w/ Mismatch as expected (good)
+    (Tc False _ [(_, Mismatch _ _ _ _)] _) -> True
+    -- anything else, pass or fail, is incorrect
+    _                                      -> False)


### PR DESCRIPTION
Closes #90, where the type error for an expression that does not match with the type of a board failed with an odd error of `!`. 

This makes a small adjustment by first adding the expression into the state monad, before type checking the expression with the type of the board. By doing so, the previous expression is able to be extracted correctly (whereas before it was missing), and the expected mismatch type error is reported normally.

Additionally, changes the error message for a missing source expression to something a bit more verbose besides `!`. Removes the associated TODO marks, as they were related to this issue before.