### PR TITLE
disallow ill-typed if and get

### DIFF
--- a/examples/illTyped/badGet.bgl
+++ b/examples/illTyped/badGet.bgl
@@ -1,0 +1,13 @@
+game G
+
+type T = {A}
+
+a : T
+a = A
+
+b : Board
+b!(x, y) = 1
+
+-- only a board should be allowed on the left side of !
+err : Int
+err = a ! (1,1)

--- a/examples/illTyped/badIf.bgl
+++ b/examples/illTyped/badIf.bgl
@@ -1,0 +1,10 @@
+game G
+
+type T = {A}
+
+a : T
+a = A
+
+-- only bool should be allowed in the condition
+err : Int
+err = if a then 1 else 2

--- a/src/Typechecker/Monad.hs
+++ b/src/Typechecker/Monad.hs
@@ -154,6 +154,12 @@ unify (X y z) (X w k)
   | w <= y = return $ X y (z `S.union` k)
 unify a b = mismatch (Plain a) (Plain b)
 
+-- | Check if t1 has type t2 with subsumption (i.e. by subtyping)
+hasType :: Xtype -> Xtype -> Typechecked Xtype
+hasType (Tup xs) (Tup ys)
+  | length xs == length ys = Tup <$> zipWithM hasType xs ys
+hasType t1 t2 = if t1 <= t2 then return t2 else mismatch (Plain t1) (Plain t2)
+
 -- | Returns a typechecked base type
 t :: Btype -> Typechecked Xtype
 t b = return (X b S.empty)

--- a/src/Typechecker/Typechecker.hs
+++ b/src/Typechecker/Typechecker.hs
@@ -120,16 +120,16 @@ exprtype (Binop Get e1 (Annotation _ (Tuple [Annotation _ (I x), Annotation _ (I
    exprtype (Binop Get e1 (Tuple [I x, I y]))
 exprtype (Binop Get e1 (Tuple [(I x), (I y)])) = do
   _t1 <- exprtype e1
-  _   <- unify _t1 (X Board S.empty)
   inB <- inBounds (x, y)
+  hasType _t1 boardxt
   if inB
-   then getPiece
-   else outofbounds (Index x) (Index y)
+     then getPiece
+     else outofbounds (Index x) (Index y)
 exprtype (Binop Get e1 e2) = do
   _t1 <- exprtype e1
   _t2 <- exprtype e2
-  _   <- unify _t1 (X Board S.empty)
-  _   <- unify _t2 (Tup [X Itype S.empty, X Itype S.empty])
+  hasType _t1 (X Board S.empty)
+  hasType _t2 (Tup [intxt, intxt])
   getPiece
 exprtype (Binop o e1 e2) = do
   _t1 <- exprtype e1
@@ -144,10 +144,9 @@ exprtype (If e1 e2 e3) = do
   _t1 <- exprtype e1
   _t2 <- exprtype e2
   t3 <- exprtype e3
-  b <- unify _t1 (X Booltype S.empty)
-  case b of
-    (X Booltype _) -> unify _t2 t3
-    _              -> unknown "Could not unify the condition for 'if' as a Boolean"
+  if _t1 == boolxt
+   then unify _t2 t3
+   else unknown $ "The condition for 'if' must be of type " ++ show (Plain boolxt)
 exprtype (HE n) = return (Hole n)
 exprtype (While c b _ _e) = do
   et <- exprtype _e


### PR DESCRIPTION
I have been aware of this for a while, so I finally fixed it with a small patch to prevent someone from running into it before the new type system is implemented.