### PR TITLE
Minor fixes

### DIFF
--- a/src/Error/Error.hs
+++ b/src/Error/Error.hs
@@ -19,13 +19,11 @@ data Error = Error {
                    }
    deriving (Eq)
 
--- Note: the error code functionality works, but only for type errors
--- the code below can be uncommented when it is introduced holistically
+-- Note: the error code functionality works, but only for type errors so they are not displayed
 instance Show Error where
-   show (Error (TE e) i p) = {-ec ++ "TE" ++ show i ++ "\n" ++-} "Type error in " ++ name ++ show e
+   show (Error (TE e) _ p) = "Type error in " ++ srcname ++ show e
       where
-         -- ec = "Error Code "
-         name = case sourceName p of
+         srcname = case sourceName p of
                   "" -> "the interpreter input " ++ show p ++ "\n"
                   _  -> show p ++ "\n"
 
@@ -45,15 +43,17 @@ instance Show Err where
 
 -- | Smart constructor for a type error that assigns an id
 cterr :: TypeError -> SourcePos -> Error
-cterr e = Error (TE e) (assign e)
+cterr terr = Error (TE terr) (assign terr)
    where
-      assign (Mismatch _ _ _)      = 0
-      assign (AppMismatch _ _ _ _) = 1
-      assign (NotBound _)          = 2
-      assign (SigMismatch _ _ _)   = 3
-      assign (Unknown _ )          = 4
-      assign (BadOp _ _ _ _)       = 5
-      assign (OutOfBounds _ _)     = 6
-      assign (BadApp _ _)          = 7
-      assign (Dereff _ _)          = 8
-      assign (Uninitialized _)     = 9
+      assign te = case te of
+                    (Mismatch _ _ _)      -> 0
+                    (AppMismatch _ _ _ _) -> 1
+                    (NotBound _)          -> 2
+                    (SigMismatch _ _ _)   -> 3
+                    (Unknown _ )          -> 4
+                    (BadOp _ _ _ _)       -> 5
+                    (OutOfBounds _ _)     -> 6
+                    (BadApp _ _)          -> 7
+                    (Dereff _ _)          -> 8
+                    (Uninitialized _)     -> 10
+                    (SigBadFeq _ _ _)     -> 11

--- a/src/Error/TypeError.hs
+++ b/src/Error/TypeError.hs
@@ -9,17 +9,18 @@ import Language.Types
 import Utils.String
 
 -- | Categories of type errors; see show instance for more detail about the error
-data TypeError = Mismatch      {t1 :: Type,  t2 :: Type, e :: Expr ()}
-               | AppMismatch   {name :: String, t1 :: Type,  t2 :: Type, e :: Expr ()}
+-- Note: any new constructors need to have a corresponding case in cterr (in Error.hs)
+data TypeError = Mismatch      {t1 :: Type,  t2 :: Type, expr :: Expr ()}
+               | AppMismatch   {name :: String, t1 :: Type,  t2 :: Type, expr :: Expr ()}
                | NotBound      {name :: String}
                | SigMismatch   {name :: String, sigType :: Type, actualType :: Type}
-               | SigBadFeq     {name :: String, sigType :: Type, feq :: Equation ()}
                | Unknown       {msg :: String}
-               | BadOp         {op :: Op, t1 :: Type, t2 :: Type, e :: Expr ()}
+               | BadOp         {op :: Op, t1 :: Type, t2 :: Type, expr :: Expr ()}
                | OutOfBounds   {xpos :: Pos, ypos :: Pos}
                | BadApp        {name :: String, arg :: Expr ()}
                | Dereff        {name :: String, typ :: Type}
                | Uninitialized {name :: String}
+               | SigBadFeq     {name :: String, sigType :: Type, feq :: Equation ()}
                deriving (Eq)
 
 instance Show TypeError where
@@ -27,10 +28,10 @@ instance Show TypeError where
   show (AppMismatch n _t1 _t2 e) = "The function " ++ n ++ " requires type " ++ show _t1 ++ " but you provided type " ++ show _t2 ++ " in expression:\n\t" ++ show e
   show (NotBound n)              = "You did not define " ++ n
   show (SigMismatch n sig _t)    = "Signature for definition " ++ quote (n ++ " : " ++ show sig) ++ "\ndoes not match actual type " ++ show _t
-  show (SigBadFeq n sig f)    = quote (n ++ " : " ++ show sig) ++ " cannot be defined with the function equation\n\t" ++ show f
   show (Unknown s)               = s
   show (BadOp o _t1 _t2 e)       = "Cannot '" ++ show o ++ "' types " ++ show _t1 ++ " and " ++ show _t2 ++ " in expression:\n\t" ++ show e
   show (OutOfBounds x y)         = "Could not access (" ++ show x ++ "," ++ show y ++ ") on the board, this is not a valid space. "
   show (BadApp n e)              = "Could not apply " ++ n ++ " to " ++ show e ++ "; it is not a function."
   show (Dereff n _t)             = "Could not dereference the function " ++ n ++ " with type " ++ show _t ++ ". Maybe you forgot to give it arguments."
   show (Uninitialized n)         = "Incomplete initialization of Board " ++ quote n
+  show (SigBadFeq n sig f)    = quote (n ++ " : " ++ show sig) ++ " cannot be defined with the function equation\n\t" ++ show f

--- a/src/Language/Syntax.hs
+++ b/src/Language/Syntax.hs
@@ -183,7 +183,7 @@ instance Show (Expr a) where
   show (B b)                = show b
   show (Ref n)              = n
   show (Tuple e)            = showAsTuple (map show e)
-  show (App n e@(Tuple es)) = n ++ show e
+  show (App n e@(Tuple _))  = n ++ show e
   show (App n e)            = n ++ parenthesize (show e)
   show (Binop o e1 e2)      = show e1 ++ show o ++ show e2
   show (Let n e1 e2)        = "let " ++ n ++ " = " ++ show e1 ++ " in " ++ show e2

--- a/src/Language/Syntax.hs
+++ b/src/Language/Syntax.hs
@@ -195,7 +195,7 @@ instance Show (ValDef a) where
   show (BVal s e _) = show s ++ "\n" ++ show e
 
 instance Show Parlist where
-  show (Pars xs) = "(" ++ intercalate (" , ") (xs) ++ ")"
+  show (Pars xs) = showAsTuple xs
 
 instance Show Signature where
   show (Sig n t) = n ++ " : " ++ show t

--- a/src/Parser/Parser.hs
+++ b/src/Parser/Parser.hs
@@ -194,8 +194,9 @@ commaSep1 :: ParsecT String u Identity a -> ParsecT String u Identity [a]
 commaSep1 = P.commaSep1 lexer
 
 -- | 0 or more comma separated values
-commaSep :: ParsecT String u Identity a -> ParsecT String u Identity [a]
-commaSep = P.commaSep lexer
+-- unused
+--commaSep :: ParsecT String u Identity a -> ParsecT String u Identity [a]
+--commaSep = P.commaSep lexer
 
 -- | Reserved ops
 reservedOp :: String -> ParsecT String u Identity ()

--- a/src/Typechecker/Monad.hs
+++ b/src/Typechecker/Monad.hs
@@ -23,8 +23,6 @@ import qualified Data.Set as S
 import Language.Syntax hiding (input)
 import Runtime.Builtins
 
-import Utils.String
-
 import Error.Error
 import Error.TypeError
 
@@ -66,7 +64,7 @@ typecheck e a = runIdentity . runExceptT . (flip runReaderT e) $
 -- | Typecheck type holes
 typeHoles :: Env -> Typechecked a -> Either Error (a, TypeEnv)
 typeHoles e a = case typecheck e a of
-  Left err -> Left err
+  Left terr -> Left terr
   Right (x, stat) -> Right (x, holes stat)
 
 -- | Add some types to the environment
@@ -159,7 +157,7 @@ unify a b = mismatch (Plain a) (Plain b)
 hasType :: Xtype -> Xtype -> Typechecked Xtype
 hasType (Tup xs) (Tup ys)
   | length xs == length ys = Tup <$> zipWithM hasType xs ys
-hasType t1 t2 = if t1 <= t2 then return t2 else mismatch (Plain t1) (Plain t2)
+hasType ta tb = if ta <= tb then return tb else mismatch (Plain ta) (Plain tb)
 
 -- | Returns a typechecked base type
 t :: Btype -> Typechecked Xtype
@@ -168,6 +166,7 @@ t b = return (X b S.empty)
 -- smart constructors for type errors
 
 -- | Gets the source expression and its position from the 'Typechecked' monad
+getInfo :: Typechecked (Expr (), SourcePos)
 getInfo = ((,) <$> getSrc <*> getPos)
 
 -- | Type mismatch error

--- a/src/Typechecker/Typechecker.hs
+++ b/src/Typechecker/Typechecker.hs
@@ -12,7 +12,6 @@ import Language.Syntax hiding (input)
 import Language.Types
 
 import Control.Monad.State
-import Control.Monad.Except
 import Control.Monad.Writer
 
 import Data.Either
@@ -83,7 +82,7 @@ eqntype _ (Function (Ft inputs _)) (Feq _ (Pars params) _e) = do
     (input') -> do
       e' <- localEnv ((++) (zip params (pure (Plain input')))) (exprtypeE _e)
       return $ Function (Ft inputs e')
-eqntype n t f = sigbadfeq n t $ (clearAnnEq f)
+eqntype n et f = sigbadfeq n et $ (clearAnnEq f)
 
 -- Synthesize the type of an expression
 exprtypeE :: (Expr SourcePos) -> Typechecked Xtype -- TODO do this with mapStateT stack thing


### PR DESCRIPTION
In fixing the issue I introduced in the PR for improving the error structure, I created a partial `cterr` function. While trying to ensure that wouldn't happen again, I realized I introduced compiler warnings so I fixed those too. Finally, I made a one line change to fix a show instance which had an extra space.