### PR TITLE
Adds GHC Options

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -4,6 +4,12 @@
 # For advanced use and comprehensive documentation of the format, please see:
 # https://docs.haskellstack.org/en/stable/yaml_configuration/
 
+#
+# GHC built options
+#
+ghc-options:
+    "$locals": -Wall -Werror=incomplete-patterns -Wno-unused-do-bind
+
 # Resolver to choose a 'specific' stackage snapshot or a compiler version.
 # A snapshot resolver dictates the compiler version and the set of packages
 # to be used for project dependencies. For example:


### PR DESCRIPTION
Adds a small section to the `stack.yml` file to include some ghc-options for building with extra warnings and errors. I tested this earlier today by reverting the fix made last night, and could verify I was still getting an incomplete-pattern error for:
- `stack build`
- `stack ghci`
- `stack install`