### PR TITLE
closes #103, report parse error for mismatched equation names

### DIFF
--- a/src/Parser/Parser.hs
+++ b/src/Parser/Parser.hs
@@ -273,7 +273,7 @@ params n = do
 equation :: String -> Parser (Equation SourcePos)
 equation eqname = do
   eqname2 <- identifier
-  guard (eqname == eqname2) <?> ("'" ++ eqname ++ "' but got " ++ eqname2 ++ "'")
+  guard (eqname == eqname2) <?> ("'" ++ eqname ++ "' but got '" ++ eqname2 ++ "'")
   (var_equation eqname) <|> (func_equation eqname)
 
 -- | Variable Equations

--- a/src/Parser/Parser.hs
+++ b/src/Parser/Parser.hs
@@ -272,20 +272,19 @@ params n = do
 -- before proceeding
 equation :: String -> Parser (Equation SourcePos)
 equation eqname = do
-  eqname2 <- identifier
-  guard (eqname == eqname2) <?> ("'" ++ eqname ++ "' but got '" ++ eqname2 ++ "'")
-  (var_equation eqname) <|> (func_equation eqname)
+  lexeme $ string eqname
+  (varEquation eqname) <|> (funcEquation eqname)
 
 -- | Variable Equations
-var_equation :: String -> Parser (Equation SourcePos)
-var_equation eqname = (try $ do
+varEquation :: String -> Parser (Equation SourcePos)
+varEquation eqname = (try $ do
   reservedOp "="
   e <- expr
   return $ Veq eqname e)
 
 -- | Function Equations
-func_equation :: String -> Parser (Equation SourcePos)
-func_equation eqname = (try $ do
+funcEquation :: String -> Parser (Equation SourcePos)
+funcEquation eqname = (try $ do
   _params <- params eqname
   putWhileNames (eqname, _params)
   reservedOp "="

--- a/test/ParserTests.hs
+++ b/test/ParserTests.hs
@@ -32,7 +32,8 @@ parserTests = TestList [
   testNestedExprInWhileOkay,
   testMisnamedDefIsParseError1,
   testMisnamedDefIsParseError2,
-  testMisnamedDefIsParseError3
+  testMisnamedDefIsParseError3,
+  testMisnamedDefWithArgsIsParseError
   ]
 
 --
@@ -571,20 +572,27 @@ testNestedExprInWhileOkay = TestCase (
 -- | Tests that a longer equation name is caught
 testMisnamedDefIsParseError1 :: Test
 testMisnamedDefIsParseError1 = TestCase (
-  assertEqual "Test that a misnamed definition triggers a parse error"
+  assertEqual "Test that a misnamed val definition triggers a parse error"
   False
   (isRight $ parseAll (many decl) "" "b:Int\nb2=2"))
 
 -- | Tests that a shorter equation name is caught
 testMisnamedDefIsParseError2 :: Test
 testMisnamedDefIsParseError2 = TestCase (
-  assertEqual "Test that a misnamed definition triggers a parse error"
+  assertEqual "Test that a misnamed val definition triggers a parse error"
   False
   (isRight $ parseAll (many decl) "" "b2:Int\nb=2"))
 
 -- | Tests that a mispelled equation name is caught
 testMisnamedDefIsParseError3 :: Test
 testMisnamedDefIsParseError3 = TestCase (
-  assertEqual "Test that a misnamed definition triggers a parse error"
+  assertEqual "Test that a misnamed val definition triggers a parse error"
   False
   (isRight $ parseAll (many decl) "" "t:Int\na=2"))
+
+-- | Tests that a mispelled equation name is caught
+testMisnamedDefWithArgsIsParseError :: Test
+testMisnamedDefWithArgsIsParseError = TestCase (
+  assertEqual "Test that a misnamed func definition triggers a parse error"
+  False
+  (isRight $ parseAll (many decl) "" "t:Int -> Int\na(x)=x+1"))

--- a/test/ParserTests.hs
+++ b/test/ParserTests.hs
@@ -29,7 +29,10 @@ parserTests = TestList [
   testOptionalBoardInputTests,
   testTypeSynCannotBeItsOwnValue,
   testIdentifiersMustBeLower,
-  testNestedExprInWhileOkay
+  testNestedExprInWhileOkay,
+  testMisnamedDefIsParseError1,
+  testMisnamedDefIsParseError2,
+  testMisnamedDefIsParseError3
   ]
 
 --
@@ -183,7 +186,7 @@ testNoRepeatedParamNames :: Test
 testNoRepeatedParamNames = TestCase $
   assertEqual "Test parse error on repeated params"
   True
-  (isLeft $ parseLine' equation ("foo(a,a) = a + a"))
+  (isLeft $ parseLine' (equation "foo") ("foo(a,a) = a + a"))
 
 
 -- | Tests parsing a board decl w/ repeated params
@@ -564,3 +567,24 @@ testNestedExprInWhileOkay = TestCase (
   assertEqual "Test that unparenthesized nested expressions are allowed in while"
   True
   (isRight $ parseAll expr "" "while x < 10 do x + 1"))
+
+-- | Tests that a longer equation name is caught
+testMisnamedDefIsParseError1 :: Test
+testMisnamedDefIsParseError1 = TestCase (
+  assertEqual "Test that a misnamed definition triggers a parse error"
+  False
+  (isRight $ parseAll (many decl) "" "b:Int\nb2=2"))
+
+-- | Tests that a shorter equation name is caught
+testMisnamedDefIsParseError2 :: Test
+testMisnamedDefIsParseError2 = TestCase (
+  assertEqual "Test that a misnamed definition triggers a parse error"
+  False
+  (isRight $ parseAll (many decl) "" "b2:Int\nb=2"))
+
+-- | Tests that a mispelled equation name is caught
+testMisnamedDefIsParseError3 :: Test
+testMisnamedDefIsParseError3 = TestCase (
+  assertEqual "Test that a misnamed definition triggers a parse error"
+  False
+  (isRight $ parseAll (many decl) "" "t:Int\na=2"))


### PR DESCRIPTION
Closes #103. This PR fixes up a previously observed bug where signatures and equations that did not match names were not caught at the parser level. This resulted in bad error reporting from the type checker instead, and was misleading as it would only trip when the type checker was invoked to verify that value or function equation. An example of an offending statement would be:
```haskell
game Test

b2 : Int -> Int
b(x) = x+1

-- or
b : Int
a = 2
```
These are now both reported correctly as parse errors (Language errors in the online tool), and are caught even if one name is a sub-string of the other name (which was not the case before).

In my local environment, this patch now correctly fails this program to parse no matter what is typed in, and reports:
```
Language Error: "Code" (line 4, column 2):
unexpected "("
expecting letter or digit or 'b2' but got b'
```
The expecting letter or digit part could be slightly improved, but this is vastly improved over the prior message.