### PR TITLE
Takes program name as an argument

### DIFF
--- a/src/API/JSONData.hs
+++ b/src/API/JSONData.hs
@@ -69,11 +69,11 @@ instance FromJSON Val where
 
 -- | Representation of input to the repl, from the user
 data SpielCommand = SpielCommand {
-    prelude   :: String,
-    file      :: String,
-    input     :: String,
-    buffer    :: [Val],
-    scFileName:: String
+    prelude     :: String,
+    file        :: String,
+    input       :: String,
+    buffer      :: [Val],
+    programName :: String
   } deriving (Eq, Show, Generic)
 
 

--- a/src/API/JSONData.hs
+++ b/src/API/JSONData.hs
@@ -69,10 +69,11 @@ instance FromJSON Val where
 
 -- | Representation of input to the repl, from the user
 data SpielCommand = SpielCommand {
-    prelude :: String,
-    file   :: String,
-    input :: String,
-    buffer :: [Val]
+    prelude   :: String,
+    file      :: String,
+    input     :: String,
+    buffer    :: [Val],
+    scFileName:: String
   } deriving (Eq, Show, Generic)
 
 

--- a/src/API/Run.hs
+++ b/src/API/Run.hs
@@ -27,13 +27,13 @@ import Runtime.Monad
 -- utilizes parsePreludeAndGameText to parse the code directly,
 -- without reading it from a file first
 _runCodeWithCommands :: SpielCommand -> IO SpielResponses
-_runCodeWithCommands sc@(SpielCommand _prelude gameFile _ _) =
-  (_handleParsed sc $ parsePreludeAndGameText _prelude gameFile)
+_runCodeWithCommands sc@(SpielCommand _prelude gameFile _ _ filename) =
+  (_handleParsed sc $ parsePreludeAndGameText _prelude gameFile filename)
 
 
 -- | Handles result of parsing a prelude and game
 _handleParsed :: SpielCommand -> IO (Either ParseError (Game SourcePos)) -> IO SpielResponses
-_handleParsed (SpielCommand _ gameFile inpt buf) parsed = do
+_handleParsed (SpielCommand _ gameFile inpt buf _) parsed = do
   pparsed <- parsed
   case pparsed of
     Right game -> do

--- a/src/Parser/Parser.hs
+++ b/src/Parser/Parser.hs
@@ -486,13 +486,13 @@ parsePreludeFromText content = parseFromText prelude "Prelude" content
 
 -- | Parse a game from text and the result of a previous parse (e.g. the prelude)
 -- Such as in the case of the function above 'Parser.Parser.parsePreludeFromtext'
-parseGameFromText :: String -> ([Maybe (ValDef SourcePos)], ParState) -> ParseResult
-parseGameFromText prog pr = parseWithState (snd pr) (parseGame (catMaybes (fst pr))) "Code" prog
+parseGameFromText :: String -> String -> ([Maybe (ValDef SourcePos)], ParState) -> ParseResult
+parseGameFromText prog fileName pr = parseWithState (snd pr) (parseGame (catMaybes (fst pr))) fileName prog
 
 -- | Parse a prelude and game from text directly, without a file
-parsePreludeAndGameText :: String -> String -> IO ParseResult
-parsePreludeAndGameText preludeContent gameFileContent = do
+parsePreludeAndGameText :: String -> String -> String -> IO ParseResult
+parsePreludeAndGameText preludeContent gameFileContent fileName = do
   prel <- return (parsePreludeFromText preludeContent)
   case prel of
-    Right r -> return (parseGameFromText gameFileContent r)
+    Right r -> return (parseGameFromText gameFileContent fileName r)
     Left err              -> return $ Left err

--- a/test/ParserTests.hs
+++ b/test/ParserTests.hs
@@ -287,7 +287,7 @@ testParseRawPreludeAndGamefile = TestCase $
   assertEqual "Test unable to parse raw prelude and gamefile text"
   True
   (case parsePreludeFromText rawPrelude of
-    Right valdefs -> isRight $ parseGameFromText rawGamecode valdefs
+    Right valdefs -> isRight $ parseGameFromText rawGamecode "Program" valdefs
     Left _        -> False
   )
 
@@ -457,7 +457,7 @@ testProperTypeSharing = TestCase (
   assertEqual "Tests that types are properly shared amongst a prelude & gamefile"
   True
   (case parsePreludeFromText "type Prelude_Type={A,B}" of
-    Right valdefs -> isRight $ parseGameFromText (sg ++ "f:Prelude_Type\nf=A") valdefs
+    Right valdefs -> isRight $ parseGameFromText (sg ++ "f:Prelude_Type\nf=A") "Program" valdefs
     Left _        -> False))
 
 


### PR DESCRIPTION
Adds a parameter to the `runCode` api called `programName`, which goes last as a string. Note that this is only the name of the program, not the prelude, which will always be called 'Prelude'. This pairs w/ a 2nd PR in the front-end to work.