### PR TITLE
Fail tc for binops between tuples of diff sizes

### DIFF
--- a/src/Typechecker/Monad.hs
+++ b/src/Typechecker/Monad.hs
@@ -29,8 +29,6 @@ import Error.TypeError
 
 import Data.List
 
--- import Debug.Trace
-
 -- | Types in the environment
 type TypeEnv = [(Name, Type)]
 
@@ -170,7 +168,10 @@ assignTypeName x = do
 --   this is to report type names like T rather than type defs like Int & {X}
 unify' :: (Xtype, Xtype) -> (Xtype, Xtype) -> Typechecked Xtype
 unify' ((Tup xns), (Tup xs)) ((Tup yns), (Tup ys)) -- element-wise unification of tuples
+  -- only unify tuples of equivalent lengths...
   | all (\x -> length x == length xs) [xns, xs, yns, ys] = Tup <$> zipWithM unify' (zip xns xs) (zip yns ys)
+  -- ...otherwise, these tuples cannot be unified
+  | otherwise = mismatch (Plain (Tup xns)) (Plain (Tup yns))
 unify' (xn, (Tup xs)) (yn, (Tup ys)) = -- expand named type and assign names to tuple elements
    do
       xns <- findTuple xn

--- a/src/Typechecker/Typechecker.hs
+++ b/src/Typechecker/Typechecker.hs
@@ -25,7 +25,6 @@ import qualified Data.Set as S
 import Utils.String
 
 import Error.Error
---import Debug.Trace
 
 {-
    - Type checker details -


### PR DESCRIPTION
Small fix to address #178 that martin brought up recently. This extends unification in the typechecker to handle & fail on the case of working with two tuple types that are not the same length. There are a couple test cases added as well to reinforce what is expected to be type-correct & incorrect when using BinOps w/ tuple operands.